### PR TITLE
Add sign

### DIFF
--- a/bin/http-signature-header-js
+++ b/bin/http-signature-header-js
@@ -41,7 +41,8 @@ program
   .command('verify')
   .action(async () => {
     try {
-      verify(program);
+      const result = await verify(program);
+      process.stdout.write(result);
       process.exit(0);
     } catch(e) {
       console.error('Verification Error:', e);

--- a/bin/http-signature-header-js
+++ b/bin/http-signature-header-js
@@ -5,7 +5,7 @@
 */
 
 const program = require('commander');
-const {createHash} = require('crypto');
+const crypto = require('crypto');
 const httpSigs = require('../lib/');
 const fs = require('fs');
 const util = require('util');
@@ -86,8 +86,8 @@ function getHTTPSignatureAlgorithm(algorithm) {
   switch(algorithm.toLowerCase()) {
     case 'hs2019': {
       return {
-        hash: createHash('sha512'),
-        dsa: ['rsa', 'hmac', 'ed']
+        sign: crypto.createSign('SHA512'),
+        dsa: ['rsa', 'hmac', 'ed', 'ECDSA']
       };
     }
     default: {
@@ -99,18 +99,18 @@ function getHTTPSignatureAlgorithm(algorithm) {
 /**
  * Runs validates on various fields.
  *
- * @param {Object} options - command line options.
+ * @param {Object} options - Command line options.
  */
 function validate(options) {
   const now = Date.now();
-  if(!isNaN(program.created)) {
-    if(program.created > now) {
+  if(!isNaN(options.created)) {
+    if(options.created > now) {
       throw new Error(
         'Invalid created. Your created parameter is in the future');
     }
   }
-  if(!isNaN(program.expires)) {
-    if(program.expires < now) {
+  if(!isNaN(options.expires)) {
+    if(options.expires < now) {
       throw new Error('Your signature has expired.');
     }
   }
@@ -143,8 +143,8 @@ program
   .action(async () => {
     try {
       const {
-        headers, keyId, privateKey, keyType,
-        algorithm, created, expires
+        headers, keyId, privateKey,
+        algorithm
       } = program;
       validate(program);
       const privateKeyFile = await readFile(privateKey);
@@ -161,7 +161,7 @@ program
       /**
        * Add HTTPSignatures headers to a given requestOptions object.
        * This is compatible with both request and axios libraries.
-       * TODO: factor out to new npm package
+       * TODO: factor out to new npm package.
        *
        * @param {Object} options - Options for the request.
        * @param {string} options.algorithm - The signing algorithm
@@ -190,25 +190,25 @@ program
         const httpSignatureAlgorithm = getHTTPSignatureAlgorithm(algorithm);
         const plaintext = httpSigs.createSignatureString(
           {includeHeaders, requestOptions});
-        const hashedText = httpSignatureAlgorithm.hash.update(plaintext);
+        httpSignatureAlgorithm.sign.write(plaintext);
+        httpSignatureAlgorithm.sign.end();
         const authzHeaderOptions = {includeHeaders, keyId};
-        const cryptoOptions = {plaintext: hashedText.digest('base64')};
         // TODO add signing support for HMAC, ECDSA, P-256,
         // Ed25519ph, Ed25519ctx, and Ed25519
         // ANSI X9.62-2005
-        if(publicKeyType.startsWith('rsa')) {
-          authzHeaderOptions.algorithm = publicKeyType;
-          const alg = publicKeyType.split('-');
-          cryptoOptions.algorithm = alg[0];
-          cryptoOptions.privateKeyPem = privateKey.toString();
-          cryptoOptions.hashType = alg[1];
-        }
-        if(publicKeyType === 'ed25519') {
-          cryptoOptions.algorithm = publicKeyType;
-          cryptoOptions.privateKeyBase58 = bs58.encode(privateKey);
+        const keyType = publicKeyType.trim().toLowerCase();
+        const valid = httpSignatureAlgorithm.dsa
+          .reduce((any, current) => {
+            if(any) {
+              return any;
+            }
+            return keyType.startsWith(current);
+          }, false);
+        if(!valid) {
+          throw new Error(`Unsupported signature algorithm ${keyType}`);
         }
         authzHeaderOptions.signature =
-          await signatureAlgorithms.sign(cryptoOptions);
+          await httpSignatureAlgorithm.sign.sign(privateKey, 'base64');
         requestOptions.headers.Authorization = httpSigs.createAuthzHeader(
           authzHeaderOptions);
         return requestOptions.headers;
@@ -218,6 +218,7 @@ program
       console.log(message);
       process.exit(0);
     } catch(e) {
+      console.error(e);
       console.error('Sign Error', JSON.stringify(e));
       process.exit(1);
     }

--- a/bin/http-signature-header-js
+++ b/bin/http-signature-header-js
@@ -227,8 +227,7 @@ program
       console.log(message);
       process.exit(0);
     } catch(e) {
-      console.error(e);
-      //console.error('Sign Error', JSON.stringify(e));
+      console.error('Sign Error', e);
       process.exit(1);
     }
   });
@@ -249,7 +248,7 @@ program
       throw new Error('Command verify has not been implemented yet.');
       process.exit(0);
     } catch(e) {
-      console.error('Verification Error:', JSON.stringify(e, null, e), e);
+      console.error('Verification Error:', e);
       process.exit(1);
     }
   });

--- a/bin/http-signature-header-js
+++ b/bin/http-signature-header-js
@@ -210,7 +210,7 @@ program
         }
         const keyObj = crypto.createPrivateKey(privateKey);
         if(keyType === 'hmac') {
-          authzHeaderOptions.signature = crypto.createHmac('SHA512', keyObj)
+          authzHeaderOptions.signature = crypto.createHmac('SHA512', privateKey)
             .update(plaintext).digest('base64');
         } else {
           const hashText = Buffer.from(

--- a/bin/http-signature-header-js
+++ b/bin/http-signature-header-js
@@ -4,135 +4,17 @@
  * Copyright (c) 2019 Digital Bazaar, Inc. All rights reserved.
 */
 
+// this module is the binary used by the http signature spec test stuies
+// @see https://github.com/w3c-dvcg/http-signatures-test-suite
 const program = require('commander');
-const crypto = require('crypto');
-const httpSigs = require('../lib/');
-const fs = require('fs');
-const util = require('util');
-const httpMessageParser = require('http-message-parser');
-const jsprim = require('jsprim');
-
-// this can be use to await paths to private keys and other files.
-// also can get be used to dereference keyId in middleware
-const readFile = util.promisify(fs.readFile);
-
-/**
- * Simple wrapper around node's process.stdin.
- * This allows us to get the result of cat and other commands.
- *
- * @param {string} [encoding='utf8'] - The http message's encoding.
- *
- * @returns {Promise<string>} Should return the http message.
- */
-async function getStdin(encoding = 'utf8') {
-  const {stdin} = process;
-  let message = '';
-  return new Promise((resolve, reject) => {
-    try {
-      stdin.setEncoding(encoding);
-      stdin.on('readable', () => {
-        let chunk;
-        while((chunk = stdin.read())) {
-          message += chunk;
-        }
-      });
-      stdin.on('end', () => resolve(message));
-      stdin.on('error', reject);
-    }
-    catch(e) {
-      reject(e);
-    }
-  });
-}
-
-/**
- * Gets a file then converts it to json.
- *
- * @param {string} file - File path.
- *
- * @returns {Object} The json object.
- */
-async function getJSON(file) {
-  const keyData = await readFile(file);
-  return JSON.parse(keyData);
-}
-
-async function getHTTPMessage() {
-  const HTTPMessage = await getStdin();
-  if(!HTTPMessage) {
-    throw new Error(
-      'An HTTP Message must be passed to stdin for this command.');
-  }
-  // this will create a request or response object
-  // similar to node's default request object.
-  return httpMessageParser(HTTPMessage);
-}
-
-function makeHTTPHeaders(headers = {}) {
-  let message = '';
-  for(const key in headers) {
-    let value = headers[key];
-    if(Array.isArray(value)) {
-      value = value.join(',');
-    }
-    message += `${key}: ${value}\n`;
-  }
-  return message;
-}
-
-function getHTTPSignatureAlgorithm(algorithm) {
-  if(algorithm === true) {
-    throw new Error(
-      'Your algorithm is not in the current HTTP Signatures registry');
-  }
-  switch(algorithm.toLowerCase()) {
-    case 'hs2019': {
-      return {
-        hash: crypto.createHash('SHA512'),
-        dsa: ['rsa', 'hmac', 'ed', 'ecdsa']
-      };
-    }
-    default: {
-      throw new Error(`${algorithm} is deprecated or unsupported}`);
-    }
-  }
-}
-
-/**
- * Runs validates on various fields.
- *
- * @param {Object} options - Command line options.
- */
-function validate(options) {
-  const now = Date.now();
-  if(!isNaN(options.created)) {
-    if(options.created > now) {
-      throw new Error(
-        'Invalid created. Your created parameter is in the future');
-    }
-  }
-  if(!isNaN(options.expires)) {
-    if(options.expires < now) {
-      throw new Error('Your signature has expired.');
-    }
-  }
-}
+const {canonicalize, sign, verify} = require('./util');
 
 program
   .command('c14n')
   .alias('canonicalize')
   .action(async () => {
     try {
-      const {headers} = program;
-      const requestOptions = await getHTTPMessage();
-      if(!headers) {throw new Error(
-        '--headers required for command c14n|canonicalize' +
-        'ex: --header date,etag');}
-      const includeHeaders =
-        program.headers ? program.headers.split(/\s+/) : '';
-      const result = httpSigs.
-        createSignatureString({includeHeaders, requestOptions});
-      console.log(result);
+      await canonicalize(program);
       process.exit(0);
     } catch(e) {
       console.error('c14n command failed : ' + e);
@@ -144,87 +26,7 @@ program
   .command('sign')
   .action(async () => {
     try {
-      const {
-        headers, keyId, privateKey,
-        algorithm
-      } = program;
-      validate(program);
-      const privateKeyFile = await readFile(privateKey);
-      const includeHeaders = headers ? program.headers.split(/\s+/) : '';
-      const requestOptions = await getHTTPMessage();
-      const options = {
-        keyId,
-        algorithm,
-        includeHeaders,
-        keyId,
-        requestOptions,
-        privateKey: privateKeyFile
-      };
-      /**
-       * Add HTTPSignatures headers to a given requestOptions object.
-       * This is compatible with both request and axios libraries.
-       * TODO: factor out to new npm package.
-       *
-       * @param {Object} options - Options for the request.
-       * @param {string} options.algorithm - The signing algorithm
-       * to use (rsa-sha256, hs2019).
-       * @param {Object} options.requestOptions - The request options.
-       * @param {string} options.keyId - A valid IRI
-       * that resolves to a public key.
-       * @param {Array<string>} options.includeHeaders - Which headers
-       * to use in the Signing String.
-       *
-       * @returns {Object} The response headers.
-      */
-      const createHttpSignatureRequest = async (
-        {algorithm = 'hs2019', privateKey, keyId,
-          requestOptions, includeHeaders = []}) => {
-        // get metadata from public key
-        const {authentication} = await getJSON(keyId);
-        const [{type: publicKeyType}] = authentication;
-        if(!publicKeyType) {
-          throw new Error('Expected public key to have key type metadata');
-        }
-        requestOptions.headers = requestOptions.headers || {};
-        if(!requestOptions.headers.date) {
-          requestOptions.headers.date = jsprim.rfc1123(new Date());
-        }
-        const httpSignatureAlgorithm = getHTTPSignatureAlgorithm(algorithm);
-        const plaintext = httpSigs.createSignatureString(
-          {includeHeaders, requestOptions});
-        httpSignatureAlgorithm.hash.update(plaintext);
-        const authzHeaderOptions = {includeHeaders, keyId};
-        // TODO add signing support for HMAC, P-256,
-        // Ed25519ph, Ed25519ctx,
-        // ANSI X9.62-2005
-        const keyType = publicKeyType.trim().toLowerCase();
-        const valid = httpSignatureAlgorithm.dsa
-          .reduce((any, current) => {
-            if(any) {
-              return any;
-            }
-            return keyType.startsWith(current);
-          }, false);
-        if(!valid) {
-          throw new Error(`Unsupported signing algorithm ${keyType}`);
-        }
-        const keyObj = crypto.createPrivateKey(privateKey);
-        if(keyType === 'hmac') {
-          authzHeaderOptions.signature = crypto.createHmac('SHA512', privateKey)
-            .update(plaintext).digest('base64');
-        } else {
-          const hashText = Buffer.from(
-            httpSignatureAlgorithm.hash.digest('utf8'), 'utf8');
-          authzHeaderOptions.signature = await crypto.sign(
-            null, hashText, keyObj).toString('base64');
-        }
-        requestOptions.headers.Authorization = httpSigs.createAuthzHeader(
-          authzHeaderOptions);
-        return requestOptions.headers;
-      };
-      const result = await createHttpSignatureRequest(options);
-      const message = makeHTTPHeaders(result);
-      console.log(message);
+      await sign(program);
       process.exit(0);
     } catch(e) {
       console.error('Sign Error', e);
@@ -237,15 +39,7 @@ program
   .command('verify')
   .action(async () => {
     try {
-      const reqJson = await getHTTPMessage();
-      const {
-        headers, keyId, privateKey, publicKey,
-        keyType, algorithm, created, expires
-      } = program;
-      const publicKeyFile = await readFile(publicKey);
-      // TODO: abstract middleware verify in this.
-      // TODO: get options from program env variables.
-      throw new Error('Command verify has not been implemented yet.');
+      verify(program);
       process.exit(0);
     } catch(e) {
       console.error('Verification Error:', e);

--- a/bin/http-signature-header-js
+++ b/bin/http-signature-header-js
@@ -194,8 +194,8 @@ program
           {includeHeaders, requestOptions});
         httpSignatureAlgorithm.hash.update(plaintext);
         const authzHeaderOptions = {includeHeaders, keyId};
-        // TODO add signing support for HMAC, ECDSA, P-256,
-        // Ed25519ph, Ed25519ctx, and Ed25519
+        // TODO add signing support for HMAC, P-256,
+        // Ed25519ph, Ed25519ctx,
         // ANSI X9.62-2005
         const keyType = publicKeyType.trim().toLowerCase();
         const valid = httpSignatureAlgorithm.dsa
@@ -209,10 +209,15 @@ program
           throw new Error(`Unsupported signing algorithm ${keyType}`);
         }
         const keyObj = crypto.createPrivateKey(privateKey);
-        const hashText = Buffer.from(
-          httpSignatureAlgorithm.hash.digest('utf8'), 'utf8');
-        authzHeaderOptions.signature =
-          await crypto.sign(null, hashText, keyObj).toString('base64');
+        if(keyType === 'hmac') {
+          authzHeaderOptions.signature = crypto.createHmac('SHA512', keyObj)
+            .update(plaintext).digest('base64');
+        } else {
+          const hashText = Buffer.from(
+            httpSignatureAlgorithm.hash.digest('utf8'), 'utf8');
+          authzHeaderOptions.signature = await crypto.sign(
+            null, hashText, keyObj).toString('base64');
+        }
         requestOptions.headers.Authorization = httpSigs.createAuthzHeader(
           authzHeaderOptions);
         return requestOptions.headers;

--- a/bin/http-signature-header-js
+++ b/bin/http-signature-header-js
@@ -5,6 +5,7 @@
 */
 
 const program = require('commander');
+const {createHash} = require('crypto');
 const httpSigs = require('../lib/');
 const fs = require('fs');
 const util = require('util');
@@ -46,6 +47,18 @@ async function getStdin(encoding = 'utf8') {
   });
 }
 
+/**
+ * Gets a file then converts it to json.
+ *
+ * @param {string} file - File path.
+ *
+ * @returns {Object} The json object.
+ */
+async function getJSON(file) {
+  const keyData = await readFile(file);
+  return JSON.parse(keyData);
+}
+
 async function getHTTPMessage() {
   const HTTPMessage = await getStdin();
   if(!HTTPMessage) {
@@ -67,6 +80,40 @@ function makeHTTPHeaders(headers = {}) {
     message += `${key}: ${value}\n`;
   }
   return message;
+}
+
+function getHTTPSignatureAlgorithm(algorithm) {
+  switch(algorithm.toLowerCase()) {
+    case 'hs2019': {
+      return {
+        hash: createHash('sha512'),
+        dsa: ['rsa', 'hmac', 'ed']
+      };
+    }
+    default: {
+      throw new Error(`${algorithm} is either deprecated or unsupported}`);
+    }
+  }
+}
+
+/**
+ * Runs validates on various fields.
+ *
+ * @param {Object} options - command line options.
+ */
+function validate(options) {
+  const now = Date.now();
+  if(!isNaN(program.created)) {
+    if(program.created > now) {
+      throw new Error(
+        'Invalid created. Your created parameter is in the future');
+    }
+  }
+  if(!isNaN(program.expires)) {
+    if(program.expires < now) {
+      throw new Error('Your signature has expired.');
+    }
+  }
 }
 
 program
@@ -99,6 +146,7 @@ program
         headers, keyId, privateKey, keyType,
         algorithm, created, expires
       } = program;
+      validate(program);
       const privateKeyFile = await readFile(privateKey);
       const includeHeaders = headers ? program.headers.split(/\s+/) : '';
       const requestOptions = await getHTTPMessage();
@@ -130,25 +178,33 @@ program
         {algorithm = 'hs2019', privateKey, keyId,
           requestOptions, includeHeaders = []}) => {
         // get metadata from public key
-        // const publicKey = await readFile(keyId);
+        const {authentication} = await getJSON(keyId);
+        const [{type: publicKeyType}] = authentication;
+        if(!publicKeyType) {
+          throw new Error('Expected public key to have key type metadata');
+        }
         requestOptions.headers = requestOptions.headers || {};
         if(!requestOptions.headers.date) {
           requestOptions.headers.date = jsprim.rfc1123(new Date());
         }
+        const httpSignatureAlgorithm = getHTTPSignatureAlgorithm(algorithm);
         const plaintext = httpSigs.createSignatureString(
           {includeHeaders, requestOptions});
+        const hashedText = httpSignatureAlgorithm.hash.update(plaintext);
         const authzHeaderOptions = {includeHeaders, keyId};
-        const cryptoOptions = {plaintext};
-        // TODO: get algorithm and has type from keyId metadata
-        if(algorithm.startsWith('rsa')) {
-          authzHeaderOptions.algorithm = algorithm;
-          const alg = algorithm.split('-');
+        const cryptoOptions = {plaintext: hashedText.digest('base64')};
+        // TODO add signing support for HMAC, ECDSA, P-256,
+        // Ed25519ph, Ed25519ctx, and Ed25519
+        // ANSI X9.62-2005
+        if(publicKeyType.startsWith('rsa')) {
+          authzHeaderOptions.algorithm = publicKeyType;
+          const alg = publicKeyType.split('-');
           cryptoOptions.algorithm = alg[0];
           cryptoOptions.privateKeyPem = privateKey.toString();
           cryptoOptions.hashType = alg[1];
         }
-        if(algorithm === 'ed25519') {
-          cryptoOptions.algorithm = algorithm;
+        if(publicKeyType === 'ed25519') {
+          cryptoOptions.algorithm = publicKeyType;
           cryptoOptions.privateKeyBase58 = bs58.encode(privateKey);
         }
         authzHeaderOptions.signature =

--- a/bin/http-signature-header-js
+++ b/bin/http-signature-header-js
@@ -14,7 +14,8 @@ program
   .alias('canonicalize')
   .action(async () => {
     try {
-      await canonicalize(program);
+      const result = await canonicalize(program);
+      process.stdout.write(result);
       process.exit(0);
     } catch(e) {
       console.error('c14n command failed : ' + e);
@@ -26,7 +27,8 @@ program
   .command('sign')
   .action(async () => {
     try {
-      await sign(program);
+      const result = await sign(program);
+      process.stdout.write(result);
       process.exit(0);
     } catch(e) {
       console.error('Sign Error', e);

--- a/bin/http-signature-header-js
+++ b/bin/http-signature-header-js
@@ -81,15 +81,19 @@ function makeHTTPHeaders(headers = {}) {
 }
 
 function getHTTPSignatureAlgorithm(algorithm) {
+  if(algorithm === true) {
+    throw new Error(
+      'Your algorithm is not in the current HTTP Signatures registry');
+  }
   switch(algorithm.toLowerCase()) {
     case 'hs2019': {
       return {
         hash: crypto.createHash('SHA512'),
-        dsa: ['rsa', 'hmac', 'ed', 'ECDSA']
+        dsa: ['rsa', 'hmac', 'ed', 'ecdsa']
       };
     }
     default: {
-      throw new Error(`${algorithm} is either deprecated or unsupported}`);
+      throw new Error(`${algorithm} is deprecated or unsupported}`);
     }
   }
 }
@@ -202,10 +206,11 @@ program
             return keyType.startsWith(current);
           }, false);
         if(!valid) {
-          throw new Error(`Unsupported signature algorithm ${keyType}`);
+          throw new Error(`Unsupported signing algorithm ${keyType}`);
         }
         const keyObj = crypto.createPrivateKey(privateKey);
-        const hashText = Buffer.from(httpSignatureAlgorithm.hash.digest('utf8'), 'utf8');
+        const hashText = Buffer.from(
+          httpSignatureAlgorithm.hash.digest('utf8'), 'utf8');
         authzHeaderOptions.signature =
           await crypto.sign(null, hashText, keyObj).toString('base64');
         requestOptions.headers.Authorization = httpSigs.createAuthzHeader(

--- a/bin/http-signature-header-js
+++ b/bin/http-signature-header-js
@@ -11,8 +11,6 @@ const fs = require('fs');
 const util = require('util');
 const httpMessageParser = require('http-message-parser');
 const jsprim = require('jsprim');
-const signatureAlgorithms = require('signature-algorithms');
-const bs58 = require('bs58');
 
 // this can be use to await paths to private keys and other files.
 // also can get be used to dereference keyId in middleware
@@ -86,7 +84,7 @@ function getHTTPSignatureAlgorithm(algorithm) {
   switch(algorithm.toLowerCase()) {
     case 'hs2019': {
       return {
-        sign: crypto.createSign('SHA512'),
+        hash: crypto.createHash('SHA512'),
         dsa: ['rsa', 'hmac', 'ed', 'ECDSA']
       };
     }
@@ -190,8 +188,7 @@ program
         const httpSignatureAlgorithm = getHTTPSignatureAlgorithm(algorithm);
         const plaintext = httpSigs.createSignatureString(
           {includeHeaders, requestOptions});
-        httpSignatureAlgorithm.sign.write(plaintext);
-        httpSignatureAlgorithm.sign.end();
+        httpSignatureAlgorithm.hash.update(plaintext);
         const authzHeaderOptions = {includeHeaders, keyId};
         // TODO add signing support for HMAC, ECDSA, P-256,
         // Ed25519ph, Ed25519ctx, and Ed25519
@@ -207,8 +204,10 @@ program
         if(!valid) {
           throw new Error(`Unsupported signature algorithm ${keyType}`);
         }
+        const keyObj = crypto.createPrivateKey(privateKey);
+        const hashText = Buffer.from(httpSignatureAlgorithm.hash.digest('utf8'), 'utf8');
         authzHeaderOptions.signature =
-          await httpSignatureAlgorithm.sign.sign(privateKey, 'base64');
+          await crypto.sign(null, hashText, keyObj).toString('base64');
         requestOptions.headers.Authorization = httpSigs.createAuthzHeader(
           authzHeaderOptions);
         return requestOptions.headers;
@@ -219,7 +218,7 @@ program
       process.exit(0);
     } catch(e) {
       console.error(e);
-      console.error('Sign Error', JSON.stringify(e));
+      //console.error('Sign Error', JSON.stringify(e));
       process.exit(1);
     }
   });

--- a/bin/http-signature-header-js-sign
+++ b/bin/http-signature-header-js-sign
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-$(dirname $0)/http-signature-header-js sign $@
+$(dirname $0)/http-signature-header-js sign "$@"
 

--- a/bin/util.js
+++ b/bin/util.js
@@ -1,0 +1,229 @@
+const crypto = require('crypto');
+const httpSigs = require('../lib/');
+const fs = require('fs');
+const util = require('util');
+const httpMessageParser = require('http-message-parser');
+const jsprim = require('jsprim');
+
+// this can be use to await paths to private keys and other files.
+// also can get be used to dereference keyId in middleware
+const readFile = util.promisify(fs.readFile);
+
+/**
+ * Simple wrapper around node's process.stdin.
+ * This allows us to get the result of cat and other commands.
+ *
+ * @param {string} [encoding='utf8'] - The http message's encoding.
+ *
+ * @returns {Promise<string>} Should return the http message.
+ */
+async function getStdin(encoding = 'utf8') {
+  const {stdin} = process;
+  let message = '';
+  return new Promise((resolve, reject) => {
+    try {
+      stdin.setEncoding(encoding);
+      stdin.on('readable', () => {
+        let chunk;
+        while((chunk = stdin.read())) {
+          message += chunk;
+        }
+      });
+      stdin.on('end', () => resolve(message));
+      stdin.on('error', reject);
+    }
+    catch(e) {
+      reject(e);
+    }
+  });
+}
+
+/**
+ * Gets a file then converts it to json.
+ *
+ * @param {string} file - File path.
+ *
+ * @returns {Object} The json object.
+ */
+async function getJSON(file) {
+  const keyData = await readFile(file);
+  return JSON.parse(keyData);
+}
+
+async function getHTTPMessage() {
+  const HTTPMessage = await getStdin();
+  if(!HTTPMessage) {
+    throw new Error(
+      'An HTTP Message must be passed to stdin for this command.');
+  }
+  // this will create a request or response object
+  // similar to node's default request object.
+  return httpMessageParser(HTTPMessage);
+}
+
+function makeHTTPHeaders(headers = {}) {
+  let message = '';
+  for(const key in headers) {
+    let value = headers[key];
+    if(Array.isArray(value)) {
+      value = value.join(',');
+    }
+    message += `${key}: ${value}\n`;
+  }
+  return message;
+}
+
+function getHTTPSignatureAlgorithm(algorithm) {
+  if(algorithm === true) {
+    throw new Error(
+      'Your algorithm is not in the current HTTP Signatures registry');
+  }
+  switch(algorithm.toLowerCase()) {
+    case 'hs2019': {
+      return {
+        hash: crypto.createHash('SHA512'),
+        dsa: ['rsa', 'hmac', 'ed', 'ecdsa']
+      };
+    }
+    default: {
+      throw new Error(`${algorithm} is deprecated or unsupported}`);
+    }
+  }
+}
+
+/**
+ * Runs validates on various fields.
+ *
+ * @param {Object} options - Command line options.
+ */
+function validate(options) {
+  const now = Date.now();
+  if(!isNaN(options.created)) {
+    if(options.created > now) {
+      throw new Error(
+        'Invalid created. Your created parameter is in the future');
+    }
+  }
+  if(!isNaN(options.expires)) {
+    if(options.expires < now) {
+      throw new Error('Your signature has expired.');
+    }
+  }
+}
+
+/**
+ * Add HTTPSignatures headers to a given requestOptions object.
+ * This is compatible with both request and axios libraries.
+ * TODO: factor out to new npm package.
+ *
+ * @param {Object} options - Options for the request.
+ * @param {string} options.algorithm - The signing algorithm
+ * to use (rsa-sha256, hs2019).
+ * @param {Object} options.requestOptions - The request options.
+ * @param {string} options.keyId - A valid IRI
+ * that resolves to a public key.
+ * @param {Array<string>} options.includeHeaders - Which headers
+ * to use in the Signing String.
+ *
+ * @returns {Object} The response headers.
+*/
+const createHttpSignatureRequest = async (
+  {algorithm = 'hs2019', privateKey, keyType,
+    requestOptions, includeHeaders = []}) => {
+  // get metadata from public key
+  if(!keyType) {
+    throw new Error('Expected to recieve keyType');
+  }
+  requestOptions.headers = requestOptions.headers || {};
+  if(!requestOptions.headers.date) {
+    requestOptions.headers.date = jsprim.rfc1123(new Date());
+  }
+  const httpSignatureAlgorithm = getHTTPSignatureAlgorithm(algorithm);
+  const plaintext = httpSigs.createSignatureString(
+    {includeHeaders, requestOptions});
+  httpSignatureAlgorithm.hash.update(plaintext);
+  const authzHeaderOptions = {includeHeaders, keyId: 'test-key'};
+  // TODO add signing support for HMAC, P-256,
+  // Ed25519ph, Ed25519ctx,
+  // ANSI X9.62-2005
+  const keyTypes = keyType.trim().toLowerCase();
+  const valid = httpSignatureAlgorithm.dsa
+    .reduce((any, current) => {
+      if(any) {
+        return any;
+      }
+      return keyTypes.startsWith(current);
+    }, false);
+  if(!valid) {
+    throw new Error(`Unsupported signing algorithm ${keyType}`);
+  }
+  const keyObj = crypto.createPrivateKey(privateKey);
+  if(keyType === 'hmac') {
+    authzHeaderOptions.signature = crypto.createHmac('SHA512', privateKey)
+      .update(plaintext).digest('base64');
+  } else {
+    const hashText = Buffer.from(
+      httpSignatureAlgorithm.hash.digest('utf8'), 'utf8');
+    authzHeaderOptions.signature = await crypto.sign(
+      null, hashText, keyObj).toString('base64');
+  }
+  requestOptions.headers.Authorization = httpSigs.createAuthzHeader(
+    authzHeaderOptions);
+  return requestOptions.headers;
+};
+
+exports.canonicalize = async function(program) {
+  const {headers} = program;
+  const requestOptions = await getHTTPMessage();
+  if(!headers) {throw new Error(
+    '--headers required for command c14n|canonicalize' +
+    'ex: --header date,etag');}
+  const includeHeaders =
+    program.headers ? program.headers.split(/\s+/) : '';
+  const result = httpSigs.
+    createSignatureString({includeHeaders, requestOptions});
+  console.log(result);
+};
+
+exports.sign = async function(program) {
+  const {
+    headers, keyType, privateKey,
+    algorithm
+  } = program;
+  validate(program);
+  if(!keyType) {
+    throw new Error('key type is required for signing');
+  }
+  if(!privateKey) {
+    throw new Error('A private key is required for signing');
+  }
+  const privateKeyFile = await readFile(privateKey);
+  const includeHeaders = headers ? program.headers.split(/\s+/) : '';
+  const requestOptions = await getHTTPMessage();
+  const options = {
+    keyType,
+    algorithm,
+    includeHeaders,
+    requestOptions,
+    privateKey: privateKeyFile
+  };
+  const result = await createHttpSignatureRequest(options);
+  const message = makeHTTPHeaders(result);
+  console.log(message);
+};
+
+exports.verify = async function(program) {
+  try {
+    const reqJson = await getHTTPMessage();
+    const {
+      headers, keyId, privateKey, publicKey,
+      keyType, algorithm, created, expires
+    } = program;
+    const publicKeyFile = await readFile(publicKey);
+    // TODO: abstract middleware verify in this.
+    // TODO: get options from program env variables.
+    throw new Error('Command verify has not been implemented yet.');
+    process.exit(0);
+  } catch(e) {
+  }
+};

--- a/bin/util.js
+++ b/bin/util.js
@@ -38,18 +38,6 @@ async function getStdin(encoding = 'utf8') {
   });
 }
 
-/**
- * Gets a file then converts it to json.
- *
- * @param {string} file - File path.
- *
- * @returns {Object} The json object.
- */
-async function getJSON(file) {
-  const keyData = await readFile(file);
-  return JSON.parse(keyData);
-}
-
 async function getHTTPMessage() {
   const HTTPMessage = await getStdin();
   if(!HTTPMessage) {
@@ -82,7 +70,7 @@ function getHTTPSignatureAlgorithm(algorithm) {
     case 'hs2019': {
       return {
         hash: crypto.createHash('SHA512'),
-        dsa: ['rsa', 'hmac', 'ed', 'ecdsa']
+        dsa: ['rsa', 'hmac', 'ed', 'ecdsa', 'p']
       };
     }
     default: {
@@ -173,13 +161,9 @@ const createHttpSignatureRequest = async (
 };
 
 exports.canonicalize = async function(program) {
-  const {headers} = program;
+  const {headers = ''} = program;
   const requestOptions = await getHTTPMessage();
-  if(!headers) {throw new Error(
-    '--headers required for command c14n|canonicalize' +
-    'ex: --header date,etag');}
-  const includeHeaders =
-    program.headers ? program.headers.split(/\s+/) : '';
+  const includeHeaders = headers.split(/\s+/);
   const result = httpSigs.
     createSignatureString({includeHeaders, requestOptions});
   console.log(result);

--- a/bin/util.js
+++ b/bin/util.js
@@ -166,7 +166,7 @@ exports.canonicalize = async function(program) {
   const includeHeaders = headers.split(/\s+/);
   const result = httpSigs.
     createSignatureString({includeHeaders, requestOptions});
-  console.log(result);
+  return result;
 };
 
 exports.sign = async function(program) {
@@ -193,7 +193,7 @@ exports.sign = async function(program) {
   };
   const result = await createHttpSignatureRequest(options);
   const message = makeHTTPHeaders(result);
-  console.log(message);
+  return message;
 };
 
 exports.verify = async function(program) {

--- a/bin/util.js
+++ b/bin/util.js
@@ -197,17 +197,12 @@ exports.sign = async function(program) {
 };
 
 exports.verify = async function(program) {
-  try {
-    const reqJson = await getHTTPMessage();
-    const {
-      headers, keyId, privateKey, publicKey,
-      keyType, algorithm, created, expires
-    } = program;
-    const publicKeyFile = await readFile(publicKey);
-    // TODO: abstract middleware verify in this.
-    // TODO: get options from program env variables.
-    throw new Error('Command verify has not been implemented yet.');
-    process.exit(0);
-  } catch(e) {
-  }
+  const reqJson = await getHTTPMessage();
+  const {
+    headers, keyId, privateKey, publicKey,
+    keyType, algorithm, created, expires
+  } = program;
+  const publicKeyFile = await readFile(publicKey);
+  // TODO: abstract middleware verify in this.
+  // TODO: get options from program env variables.
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-/*!
+/*
  * This implementation was based in part on
  * https://github.com/joyent/node-http-signature
  * Copyright 2012 Joyent, Inc.  All rights reserved.
@@ -301,7 +301,8 @@ function _signingString(
       result.push(`${h}: ${value}`);
     }
   }
-  return result.join('\n');
+  // remove the trailing new line
+  return result.join('\n').replace(/\s$/, '');
 }
 
 function _parseHostAndPath(url) {


### PR DESCRIPTION
Adds a sign function to the binary.

Basic Example Command:
```
cat ../http-signatures-test-suite/test/latest/input/default-test.httpMessage | ./bin/http-signature-header-js-sign --headers "Digest" --private-key ../../../keys/ed25519.private --keyId ./node_modules/mock_keys/ed-mock-pub.json
```

Passes:

- MUST require key type.
- MUST base64 encode signature (I believe it is)
- MUST produce an error if the key type type is not in the http signature types
- MUST produce an error if the --algorithm is not in the http signature registry
- MUST produce an error if the --algorithm is deprecated
- MUST sign if the --algorithm is not deprecated i.e. hs2019
- MUST not process if --created is in the future
- MUST not process if --expires is in the past