### PR TITLE
Correct expires & created validation to use unix time stamps.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # http-signature-header
 
+## 2.0.0 -
+
+### Fixed
+- Pseudo-headers `created` & `expires` must be unix time stamps or js Dates.
+
+### Added
+- Validators for `created` & `expires`.
+- Tests for `parseRequest`.
+
 ## 1.3.1 - 2019-07-18
 
 ### Fixed

--- a/bin/util.js
+++ b/bin/util.js
@@ -44,26 +44,6 @@ function getHTTPSignatureAlgorithm(algorithm) {
 }
 
 /**
- * Runs validates on various fields.
- *
- * @param {Object} options - Command line options.
- */
-function validate(options) {
-  const now = Date.now();
-  if(!isNaN(options.created)) {
-    if(options.created * 1000 > now) {
-      throw new Error(
-        'Invalid created. Your created parameter is in the future');
-    }
-  }
-  if(!isNaN(options.expires)) {
-    if(options.expires * 1000 < now) {
-      throw new Error('Your signature has expired.');
-    }
-  }
-}
-
-/**
  * Simple validator for a private key that ensures
  * the key is either secret for hmac or private.
  *

--- a/bin/util.js
+++ b/bin/util.js
@@ -135,7 +135,6 @@ exports.sign = async function(
     headers, keyType, privateKey,
     algorithm
   } = program;
-  validate(program);
   if(!keyType) {
     throw new Error('key type is required for signing');
   }
@@ -166,7 +165,6 @@ exports.verify = async function(
     * 5. pass publicKey, canonziedString, and decoded signature bytes to verify
    */
   const {headers = '', keyType, algorithm = 'hs2019'} = program;
-  validate(program);
   const includeHeaders = headers;
   let canonicalizedString = httpSigs.
     createSignatureString({includeHeaders, requestOptions});

--- a/bin/util.js
+++ b/bin/util.js
@@ -51,13 +51,13 @@ function getHTTPSignatureAlgorithm(algorithm) {
 function validate(options) {
   const now = Date.now();
   if(!isNaN(options.created)) {
-    if(options.created > now) {
+    if(options.created * 1000 > now) {
       throw new Error(
         'Invalid created. Your created parameter is in the future');
     }
   }
   if(!isNaN(options.expires)) {
-    if(options.expires < now) {
+    if(options.expires * 1000 < now) {
       throw new Error('Your signature has expired.');
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -215,7 +215,7 @@ function validateDate(date, key) {
     if(key === 'expires') {
       return Math.floor(timestamp);
     }
-    throw new TypeError(`Unknown date pseudo-header ${key}`);
+    throw new TypeError(`Unknown date pseudo-header "${key}".`);
   }
   if(Number.isInteger(date)) {
     // we need to accept that the integer is a unix time stamp

--- a/lib/index.js
+++ b/lib/index.js
@@ -244,7 +244,7 @@ function validateDateRange(options, now) {
   if(typeof possibleCreated === 'number') {
     if(options.created > now) {
       throw new Error(
-        'Invalid created. Your created pseudo-header is in the future');
+        'Invalid signature; the signature creation time is in the future.');
     }
     options.created = possibleCreated;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -210,10 +210,7 @@ function validateDate(date, key) {
   }
   if(date instanceof Date) {
     const timestamp = date.getTime() / 1000;
-    if(key === 'created') {
-      return Math.ceil(timestamp);
-    }
-    if(key === 'expires') {
+    if(key === 'created' || key === 'expires') {
       return Math.floor(timestamp);
     }
     throw new TypeError(`Unknown date pseudo-header "${key}".`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -255,6 +255,7 @@ api.parseRequest = (request, options) => {
   const authz = request.headers[authzHeaderName];
   const parsed = parseSignatureHeader(authz);
 
+  // headers are optional and default to (created)
   if(!parsed.params.headers) {
     if(request.headers['x-date']) {
       parsed.params.headers = ['x-date'];
@@ -264,7 +265,6 @@ api.parseRequest = (request, options) => {
   } else {
     parsed.params.headers = parsed.params.headers.split(/\s+/);
   }
-
   // Minimally validate the parsed object
   if(!parsed.scheme || parsed.scheme !== 'Signature') {
     throw new HttpSignatureError('scheme was not "Signature"', 'SyntaxError');

--- a/lib/index.js
+++ b/lib/index.js
@@ -295,7 +295,6 @@ api.parseRequest = (request, options) => {
     includeHeaders, headers,
     method, host, path, requestOptions, validate: _validateReceiveHeader
   });
-
   // Check against the constraints
   if(request.headers.expires ||
     request.headers.date || request.headers['x-date']) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -240,6 +240,8 @@ function validateDate(date, key) {
  * @returns {Object} Formatted options.
 */
 function validateDateRange(options, now) {
+  // shallow copy options
+  options = {...options};
   const possibleCreated = validateDate(options.created, 'created');
   if(typeof possibleCreated === 'number') {
     if(options.created > now) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -218,10 +218,9 @@ function validateDate(date, key) {
     if(!Number.isNaN(number)) {
       return number;
     }
-  } else {
-    throw new TypeError(
-      `"${key}" must be a UNIX timestamp or JavaScript Date.`);
   }
+  throw new TypeError(
+    `"${key}" must be a UNIX timestamp or JavaScript Date.`);
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -208,14 +208,25 @@ function validateDate(date, key) {
     return date;
   }
   if(date instanceof Date) {
-    return (Math.round(date.getTime() / 1000));
-  } else if(Number.isInteger(date)) {
+    const timestamp = date.getTime() / 1000;
+    if(key === 'created') {
+      // using Math.ceil here can result
+      // in timestamps that are 1 second in the future
+      return Math.floor(timestamp);
+    }
+    if(key === 'expires') {
+      return Math.ceil(timestamp);
+    }
+    return Math.round(timestamp);
+  }
+  if(Number.isInteger(date)) {
     // we need to accept that the integer is a unix time stamp
     return date;
-  } else if(typeof(date) === 'string') {
+  }
+  if(typeof date === 'string') {
     // we assume this is a unix time stamp too
     const number = Number(date);
-    if(!Number.isNaN(number)) {
+    if(Number.isInteger(number)) {
       return number;
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -225,7 +225,7 @@ function validateDate(date, key) {
 }
 
 /**
- * Validates and formats date psuedo-headers.
+ * Validates and formats date pseudo-headers.
  *
  * @param {Object} options - Options to use.
  *
@@ -239,7 +239,7 @@ function validateDates(options) {
   if(typeof(possibleCreated) === 'number') {
     if(possibleCreated > now) {
       throw new Error(
-        'Invalid created. Your created psuedo-header is in the future');
+        'Invalid created. Your created pseudo-header is in the future');
     }
     options.created = possibleCreated;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -218,7 +218,7 @@ function validateDate(date, key) {
     throw new TypeError(`Unknown date pseudo-header "${key}".`);
   }
   if(Number.isInteger(date)) {
-    // we need to accept that the integer is a unix time stamp
+    // we assume the integer is a unix time stamp
     return date;
   }
   if(typeof date === 'string') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -355,7 +355,8 @@ api.parseRequest = (request, options) => {
   // Check against the constraints
   if(request.headers.expires ||
     request.headers.date || request.headers['x-date']) {
-    const now = new Date(_now);
+    // _now is a unix timestamp so multiple by 1000 to get a valid JS Date
+    const now = new Date(_now * 1000);
     if(request.headers.expires) {
       const date = new Date(request.headers.expires);
       if(now > date) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -210,14 +210,12 @@ function validateDate(date, key) {
   if(date instanceof Date) {
     const timestamp = date.getTime() / 1000;
     if(key === 'created') {
-      // using Math.ceil here can result
-      // in timestamps that are 1 second in the future
-      return Math.floor(timestamp);
-    }
-    if(key === 'expires') {
       return Math.ceil(timestamp);
     }
-    return Math.round(timestamp);
+    if(key === 'expires') {
+      return Math.floor(timestamp);
+    }
+    throw new TypeError(`Unknown date pseudo-header ${key}`);
   }
   if(Number.isInteger(date)) {
     // we need to accept that the integer is a unix time stamp
@@ -242,12 +240,10 @@ function validateDate(date, key) {
  * @returns {Object} Formatted options.
 */
 function validateDates(options) {
-  // we need now in seconds
-  const now = Math.round(Date.now() / 1000);
   // created could be a number
   const possibleCreated = validateDate(options.created, 'created');
   if(typeof(possibleCreated) === 'number') {
-    if(possibleCreated > now) {
+    if(possibleCreated > Math.ceil(Date.now() / 1000)) {
       throw new Error(
         'Invalid created. Your created pseudo-header is in the future');
     }
@@ -256,7 +252,7 @@ function validateDates(options) {
   // expires could be a number
   const possibleExpires = validateDate(options.expires, 'expires');
   if(typeof(possibleExpires) === 'number') {
-    if(possibleExpires < now) {
+    if(possibleExpires < Math.floor(Date.now() / 1000)) {
       throw new Error('Your signature has expired.');
     }
     options.expires = possibleExpires;

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,11 +175,12 @@ api.createAuthzHeader = (
   }
   params.headers = includeHeaders.join(' ');
   params.signature = signature;
-  if(created !== undefined) {
-    params.created = created;
+  const dates = validateDates({created, expires});
+  if(typeof dates.created === 'number') {
+    params.created = dates.created;
   }
-  if(expires !== undefined) {
-    params.expires = expires;
+  if(typeof dates.expires === 'number') {
+    params.expires = dates.expires;
   }
   return 'Signature ' +
     Object.keys(params).map(k => `${k}="${params[k]}"`).join(',');
@@ -232,30 +233,48 @@ function validateDate(date, key) {
 }
 
 /**
- * Validates and formats date pseudo-headers.
+ * Ensures that date based pseudo-headers are unix time stamps.
+ *
+ * @param {Object} options - Options to use.
+ *
+ * @returns {Object} Formatted options.
+*/
+function validateDates(options) {
+  // created could be a number
+  const possibleCreated = validateDate(options.created, 'created');
+  if(typeof possibleCreated === 'number') {
+    options.created = possibleCreated;
+  }
+  // expires could be a number
+  const possibleExpires = validateDate(options.expires, 'expires');
+  if(typeof possibleExpires === 'number') {
+    options.expires = possibleExpires;
+  }
+  return options;
+}
+
+/**
+ * Ensures date based psuedo-headers are valid timestamps and
+ *  are not invalid or expired.
  *
  * @param {Object} options - Options to use.
  * @param {number} now - A unix timestamp for now.
  *
  * @returns {Object} Formatted options.
 */
-function validateDates(options, now) {
-  // created could be a number
-  const possibleCreated = validateDate(options.created, 'created');
-  if(typeof possibleCreated === 'number') {
-    if(possibleCreated > now) {
+
+function validateDateRange(options, now) {
+  options = validateDates(options);
+  if(typeof options.created === 'number') {
+    if(options.created > now) {
       throw new Error(
         'Invalid created. Your created pseudo-header is in the future');
     }
-    options.created = possibleCreated;
   }
-  // expires could be a number
-  const possibleExpires = validateDate(options.expires, 'expires');
-  if(typeof(possibleExpires) === 'number') {
-    if(possibleExpires < now) {
+  if(typeof options.expires === 'number') {
+    if(options.expires < now) {
       throw new Error('Your signature has expired.');
     }
-    options.expires = possibleExpires;
   }
   return options;
 }
@@ -343,8 +362,8 @@ api.parseRequest = (request, options, now = Math.floor(Date.now() / 1000)) => {
   }
   const {headers: rawHeaders, method, url} = request;
   const headers = lowerCaseObjectKeys(rawHeaders);
-  const requestOptions = extractPseudoHeaders(parsed.params, headers);
-  validateDates(requestOptions, now);
+  let requestOptions = extractPseudoHeaders(parsed.params, headers);
+  requestOptions = validateDateRange(requestOptions, now);
   const {host, path} = _parseHostAndPath(url);
   parsed.signingString = _signingString({
     includeHeaders, headers,

--- a/lib/index.js
+++ b/lib/index.js
@@ -204,7 +204,7 @@ function lowerCaseObjectKeys(obj) {
 
 function validateDate(date, key) {
   // created & expires are not required
-  if((date === undefined) || (date === null)) {
+  if(date === undefined || date === null) {
     return date;
   }
   if(date instanceof Date) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -289,7 +289,7 @@ api.createSignatureString = ({includeHeaders, requestOptions} = {}) => {
   });
 };
 
-api.parseRequest = (request, options, now = Math.floor(Date.now() / 1000)) => {
+api.parseRequest = (request, options) => {
   assert.object(request, 'request');
   assert.object(request.headers, 'request.headers');
   if(options === undefined) {
@@ -346,6 +346,7 @@ api.parseRequest = (request, options, now = Math.floor(Date.now() / 1000)) => {
   const {headers: rawHeaders, method, url} = request;
   const headers = lowerCaseObjectKeys(rawHeaders);
   let requestOptions = extractPseudoHeaders(parsed.params, headers);
+  const now = options.now || Math.floor(Date.now() / 1000);
   requestOptions = validateDateRange(requestOptions, now);
   const {host, path} = _parseHostAndPath(url);
   parsed.signingString = _signingString({

--- a/lib/index.js
+++ b/lib/index.js
@@ -203,69 +203,13 @@ function lowerCaseObjectKeys(obj) {
   return newObject;
 }
 
-function validateDate(date, key) {
-  // created & expires are not required
-  if(date === undefined || date === null) {
-    return date;
-  }
-  if(date instanceof Date) {
-    const timestamp = date.getTime() / 1000;
-    if(key === 'created' || key === 'expires') {
-      return Math.floor(timestamp);
-    }
-    throw new TypeError(`Unknown date pseudo-header "${key}".`);
-  }
-  if(Number.isInteger(date)) {
-    // we assume the integer is a unix time stamp
-    return date;
-  }
-  if(typeof date === 'string') {
-    // we assume this is a unix time stamp too
-    const number = Number(date);
-    if(Number.isInteger(number)) {
-      return number;
-    }
-  }
-  throw new TypeError(
-    `"${key}" must be a UNIX timestamp or JavaScript Date.`);
-}
-
-/**
- * Ensures date based psuedo-headers are valid timestamps and
- *  are not invalid or expired.
- *
- * @param {Object} options - Options to use.
- * @param {number} now - A unix timestamp to use as the current time.
- *
- * @returns {Object} Formatted options.
-*/
-function validateDateRange(options, now) {
-  // shallow copy options
-  options = {...options};
-  const possibleCreated = validateDate(options.created, 'created');
-  if(typeof possibleCreated === 'number') {
-    if(options.created > now) {
-      throw new Error(
-        'Invalid signature; the signature creation time is in the future.');
-    }
-    options.created = possibleCreated;
-  }
-  const possibleExpires = validateDate(options.expires, 'expires');
-  if(typeof possibleExpires === 'number') {
-    if(options.expires < now) {
-      throw new Error('The signature has expired.');
-    }
-    options.expires = possibleExpires;
-  }
-  return options;
-}
-
 api.createSignatureString = ({includeHeaders, requestOptions} = {}) => {
   assert.object(requestOptions, 'requestOptions');
   assert.object(requestOptions.headers, 'requestOption.headers');
   assert.string(requestOptions.method, 'requestOption.method');
   assert.string(requestOptions.url, 'requestOption.url');
   assert.optionalArrayOfString(includeHeaders, 'headers');
+
   // normalize headers to lowercase
   const headers = lowerCaseObjectKeys(requestOptions.headers);
   if(!includeHeaders) {
@@ -483,3 +427,72 @@ function _parseHostAndPath(url) {
       `An invalid url "${url}" was specified.`, 'SyntaxError');
   }
 }
+
+/**
+ * Validates a single potential unix time stamp or Javascript date.
+ *
+ * @param {string|number|Date} date - A potential unix timestamp or js Date.
+ * @param {'created'|'expires'} key - An identifier for the date.
+ *
+ * @throws {TypeError} throws if the date is invalid.
+ *
+ * @returns {undefined|null|number} Returns a number if there was a valid
+ *  date passed in and undefined or null if there was no date.
+*/
+function validateDate(date, key) {
+  // created & expires are not required
+  if(date === undefined || date === null) {
+    return date;
+  }
+  if(date instanceof Date) {
+    const timestamp = date.getTime() / 1000;
+    if(key === 'created' || key === 'expires') {
+      return Math.floor(timestamp);
+    }
+    throw new TypeError(`Unknown date pseudo-header "${key}".`);
+  }
+  if(Number.isInteger(date)) {
+    // we assume the integer is a unix time stamp
+    return date;
+  }
+  if(typeof date === 'string') {
+    // we assume this is a unix time stamp too
+    const number = Number(date);
+    if(Number.isInteger(number)) {
+      return number;
+    }
+  }
+  throw new TypeError(
+    `"${key}" must be a UNIX timestamp or JavaScript Date.`);
+}
+
+/**
+ * Ensures date based psuedo-headers are valid timestamps and
+ *  are not invalid or expired.
+ *
+ * @param {Object} options - Options to use.
+ * @param {number} now - A unix timestamp to use as the current time.
+ *
+ * @returns {Object} Formatted options.
+*/
+function validateDateRange(options, now) {
+  // shallow copy options
+  options = {...options};
+  const possibleCreated = validateDate(options.created, 'created');
+  if(typeof possibleCreated === 'number') {
+    if(options.created > now) {
+      throw new Error(
+        'Invalid signature; the signature creation time is in the future.');
+    }
+    options.created = possibleCreated;
+  }
+  const possibleExpires = validateDate(options.expires, 'expires');
+  if(typeof possibleExpires === 'number') {
+    if(options.expires < now) {
+      throw new Error('The signature has expired.');
+    }
+    options.expires = possibleExpires;
+  }
+  return options;
+}
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -215,13 +215,65 @@ function lowerCaseObjectKeys(obj) {
   return newObject;
 }
 
+function validateDate(date, key) {
+  // created & expires are not required
+  if((date === undefined) || (date === null)) {
+    return date;
+  }
+  if(date instanceof Date) {
+    return (Math.round(date.getTime() / 1000));
+  } else if(Number.isInteger(date)) {
+    // we need to accept that the integer is a unix time stamp
+    return date;
+  } else if(typeof(date) === 'string') {
+    // we assume this is a unix time stamp too
+    const number = Number(date);
+    if(!Number.isNaN(number)) {
+      return number;
+    }
+  } else {
+    throw new TypeError(
+      `"${key}" must be a UNIX timestamp or JavaScript Date.`);
+  }
+}
+
+/**
+ * Validates and formats options.
+ *
+ * @param {Object} options - Options to use.
+ *
+ * @returns {Object} Formatted options.
+*/
+function validate(options) {
+  // we need now in seconds
+  const now = Math.round(Date.now() / 1000);
+  // created could be a number
+  const possibleCreated = validateDate(options.created, 'created');
+  if(typeof(possibleCreated) === 'number') {
+    if(possibleCreated > now) {
+      throw new Error(
+        'Invalid created. Your created psuedo-header is in the future');
+    }
+    options.created = possibleCreated;
+  }
+  // expires could be a number
+  const possibleExpires = validateDate(options.expires, 'expires');
+  if(typeof(possibleExpires) === 'number') {
+    if(possibleExpires < now) {
+      throw new Error('Your signature has expired.');
+    }
+    options.expires = possibleExpires;
+  }
+  return options;
+}
+
 api.createSignatureString = ({includeHeaders, requestOptions} = {}) => {
   assert.object(requestOptions, 'requestOptions');
   assert.object(requestOptions.headers, 'requestOption.headers');
   assert.string(requestOptions.method, 'requestOption.method');
   assert.string(requestOptions.url, 'requestOption.url');
   assert.optionalArrayOfString(includeHeaders, 'headers');
-
+  validate(requestOptions);
   // normalize headers to lowercase
   const headers = lowerCaseObjectKeys(requestOptions.headers);
   if(!includeHeaders) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -251,7 +251,7 @@ function validateDateRange(options, now) {
   const possibleExpires = validateDate(options.expires, 'expires');
   if(typeof possibleExpires === 'number') {
     if(options.expires < now) {
-      throw new Error('Your signature has expired.');
+      throw new Error('The signature has expired.');
     }
     options.expires = possibleExpires;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,12 +175,13 @@ api.createAuthzHeader = (
   }
   params.headers = includeHeaders.join(' ');
   params.signature = signature;
-  const dates = validateDates({created, expires});
-  if(typeof dates.created === 'number') {
-    params.created = dates.created;
+  const _created = validateDate(created, 'created');
+  if(typeof _created === 'number') {
+    params.created = _created;
   }
-  if(typeof dates.expires === 'number') {
-    params.expires = dates.expires;
+  const _expires = validateDate(expires, 'expires');
+  if(typeof _expires === 'number') {
+    params.expires = _expires;
   }
   return 'Signature ' +
     Object.keys(params).map(k => `${k}="${params[k]}"`).join(',');
@@ -233,27 +234,6 @@ function validateDate(date, key) {
 }
 
 /**
- * Ensures that date based pseudo-headers are unix time stamps.
- *
- * @param {Object} options - Options to use.
- *
- * @returns {Object} Formatted options.
-*/
-function validateDates(options) {
-  // created could be a number
-  const possibleCreated = validateDate(options.created, 'created');
-  if(typeof possibleCreated === 'number') {
-    options.created = possibleCreated;
-  }
-  // expires could be a number
-  const possibleExpires = validateDate(options.expires, 'expires');
-  if(typeof possibleExpires === 'number') {
-    options.expires = possibleExpires;
-  }
-  return options;
-}
-
-/**
  * Ensures date based psuedo-headers are valid timestamps and
  *  are not invalid or expired.
  *
@@ -264,17 +244,20 @@ function validateDates(options) {
 */
 
 function validateDateRange(options, now) {
-  options = validateDates(options);
-  if(typeof options.created === 'number') {
+  const possibleCreated = validateDate(options.created, 'created');
+  if(typeof possibleCreated === 'number') {
     if(options.created > now) {
       throw new Error(
         'Invalid created. Your created pseudo-header is in the future');
     }
+    options.created = possibleCreated;
   }
-  if(typeof options.expires === 'number') {
+  const possibleExpires = validateDate(options.expires, 'expires');
+  if(typeof possibleExpires === 'number') {
     if(options.expires < now) {
       throw new Error('Your signature has expired.');
     }
+    options.expires = possibleExpires;
   }
   return options;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -235,14 +235,15 @@ function validateDate(date, key) {
  * Validates and formats date pseudo-headers.
  *
  * @param {Object} options - Options to use.
+ * @param {number} now - A unix timestamp for now.
  *
  * @returns {Object} Formatted options.
 */
-function validateDates(options) {
+function validateDates(options, now) {
   // created could be a number
   const possibleCreated = validateDate(options.created, 'created');
   if(typeof(possibleCreated) === 'number') {
-    if(possibleCreated > Math.ceil(Date.now() / 1000)) {
+    if(possibleCreated > now) {
       throw new Error(
         'Invalid created. Your created pseudo-header is in the future');
     }
@@ -251,7 +252,7 @@ function validateDates(options) {
   // expires could be a number
   const possibleExpires = validateDate(options.expires, 'expires');
   if(typeof(possibleExpires) === 'number') {
-    if(possibleExpires < Math.floor(Date.now() / 1000)) {
+    if(possibleExpires < now) {
       throw new Error('Your signature has expired.');
     }
     options.expires = possibleExpires;

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,12 +175,11 @@ api.createAuthzHeader = (
   }
   params.headers = includeHeaders.join(' ');
   params.signature = signature;
-  const dates = validateDates({created, expires});
-  if(typeof dates.created === 'number') {
-    params.created = dates.created;
+  if(created !== undefined) {
+    params.created = created;
   }
-  if(typeof dates.expires === 'number') {
-    params.expires = dates.expires;
+  if(expires !== undefined) {
+    params.expires = expires;
   }
   return 'Signature ' +
     Object.keys(params).map(k => `${k}="${params[k]}"`).join(',');
@@ -266,7 +265,6 @@ api.createSignatureString = ({includeHeaders, requestOptions} = {}) => {
   assert.string(requestOptions.method, 'requestOption.method');
   assert.string(requestOptions.url, 'requestOption.url');
   assert.optionalArrayOfString(includeHeaders, 'headers');
-  validateDates(requestOptions);
   // normalize headers to lowercase
   const headers = lowerCaseObjectKeys(requestOptions.headers);
   if(!includeHeaders) {
@@ -288,7 +286,7 @@ api.createSignatureString = ({includeHeaders, requestOptions} = {}) => {
   });
 };
 
-api.parseRequest = (request, options) => {
+api.parseRequest = (request, options, now = Math.floor(Date.now() / 1000)) => {
   assert.object(request, 'request');
   assert.object(request.headers, 'request.headers');
   if(options === undefined) {
@@ -345,6 +343,7 @@ api.parseRequest = (request, options) => {
   const {headers: rawHeaders, method, url} = request;
   const headers = lowerCaseObjectKeys(rawHeaders);
   const requestOptions = extractPseudoHeaders(parsed.params, headers);
+  validateDates(requestOptions, now);
   const {host, path} = _parseHostAndPath(url);
   parsed.signingString = _signingString({
     includeHeaders, headers,

--- a/lib/index.js
+++ b/lib/index.js
@@ -239,7 +239,6 @@ function validateDate(date, key) {
  *
  * @returns {Object} Formatted options.
 */
-
 function validateDateRange(options, now) {
   const possibleCreated = validateDate(options.created, 'created');
   if(typeof possibleCreated === 'number') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -235,7 +235,7 @@ function validateDate(date, key) {
  *  are not invalid or expired.
  *
  * @param {Object} options - Options to use.
- * @param {number} now - A unix timestamp for now.
+ * @param {number} now - A unix timestamp to use as the current time.
  *
  * @returns {Object} Formatted options.
 */

--- a/lib/index.js
+++ b/lib/index.js
@@ -176,7 +176,7 @@ api.createAuthzHeader = (
   params.headers = includeHeaders.join(' ');
   params.signature = signature;
   const dates = validateDates({created, expires});
-  if((typeof dates.created) == 'number') {
+  if(typeof dates.created === 'number') {
     params.created = dates.created;
   }
   if((typeof dates.expires) === 'number') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -242,7 +242,7 @@ function validateDate(date, key) {
 function validateDates(options, now) {
   // created could be a number
   const possibleCreated = validateDate(options.created, 'created');
-  if(typeof(possibleCreated) === 'number') {
+  if(typeof possibleCreated === 'number') {
     if(possibleCreated > now) {
       throw new Error(
         'Invalid created. Your created pseudo-header is in the future');

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,25 +175,12 @@ api.createAuthzHeader = (
   }
   params.headers = includeHeaders.join(' ');
   params.signature = signature;
-  if(created !== undefined) {
-    if(created instanceof Date) {
-      params.created = created.getTime();
-    } else if(Number.isInteger(created)) {
-      params.created = created;
-    } else {
-      throw new TypeError(
-        '"created" must be a UNIX timestamp or JavaScript Date.');
-    }
+  const dates = validateDates({created, expires});
+  if((typeof dates.created) == 'number') {
+    params.created = dates.created;
   }
-  if(expires !== undefined) {
-    if(expires instanceof Date) {
-      params.expires = expires.getTime();
-    } else if(Number.isInteger(expires)) {
-      params.expires = expires;
-    } else {
-      throw new TypeError(
-        '"expires" must be a UNIX timestamp or JavaScript Date.');
-    }
+  if((typeof dates.expires) === 'number') {
+    params.expires = dates.expires;
   }
   return 'Signature ' +
     Object.keys(params).map(k => `${k}="${params[k]}"`).join(',');
@@ -238,13 +225,13 @@ function validateDate(date, key) {
 }
 
 /**
- * Validates and formats options.
+ * Validates and formats date psuedo-headers.
  *
  * @param {Object} options - Options to use.
  *
  * @returns {Object} Formatted options.
 */
-function validate(options) {
+function validateDates(options) {
   // we need now in seconds
   const now = Math.round(Date.now() / 1000);
   // created could be a number
@@ -273,7 +260,7 @@ api.createSignatureString = ({includeHeaders, requestOptions} = {}) => {
   assert.string(requestOptions.method, 'requestOption.method');
   assert.string(requestOptions.url, 'requestOption.url');
   assert.optionalArrayOfString(includeHeaders, 'headers');
-  validate(requestOptions);
+  validateDates(requestOptions);
   // normalize headers to lowercase
   const headers = lowerCaseObjectKeys(requestOptions.headers);
   if(!includeHeaders) {
@@ -424,7 +411,7 @@ function addValue({result, validate, key, values, label}) {
     value = value.join(', ');
   }
   if(value instanceof Date) {
-    // only PSEUDO_HEADERS have to be unix timestamps
+    // only PSEUDO_HEADERS created & expires have to be unix timestamps
     if(label in PSEUDO_HEADERS) {
       value = value.getTime();
     } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -179,7 +179,7 @@ api.createAuthzHeader = (
   if(typeof dates.created === 'number') {
     params.created = dates.created;
   }
-  if((typeof dates.expires) === 'number') {
+  if(typeof dates.expires === 'number') {
     params.expires = dates.expires;
   }
   return 'Signature ' +

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
  * https://github.com/joyent/node-http-signature
  * Copyright 2012 Joyent, Inc.  All rights reserved.
  *
- * Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2020 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -344,8 +344,8 @@ api.parseRequest = (request, options) => {
   const {headers: rawHeaders, method, url} = request;
   const headers = lowerCaseObjectKeys(rawHeaders);
   let requestOptions = extractPseudoHeaders(parsed.params, headers);
-  const now = options.now || Math.floor(Date.now() / 1000);
-  requestOptions = validateDateRange(requestOptions, now);
+  const _now = options.now || Math.floor(Date.now() / 1000);
+  requestOptions = validateDateRange(requestOptions, _now);
   const {host, path} = _parseHostAndPath(url);
   parsed.signingString = _signingString({
     includeHeaders, headers,
@@ -355,7 +355,7 @@ api.parseRequest = (request, options) => {
   // Check against the constraints
   if(request.headers.expires ||
     request.headers.date || request.headers['x-date']) {
-    const now = new Date();
+    const now = new Date(_now);
     if(request.headers.expires) {
       const date = new Date(request.headers.expires);
       if(now > date) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "cross-env": "^7.0.2",
-    "eslint": "^6.8.0",
+    "eslint": "^7.11.0",
     "eslint-config-digitalbazaar": "^2.0.0",
     "eslint-plugin-jsdoc": "^4.8.3",
     "mocha": "^6.0.0",

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -259,6 +259,97 @@ describe('http-signature', () => {
         'headers="date host (request-target)",' +
         'signature="mockSignature"');
     });
+    it('header with integer (created)', () => {
+      const created = Math.floor(Date.now() / 1000);
+      const authz = httpSignatureHeader.createAuthzHeader({
+        includeHeaders: ['date', 'host', '(request-target)', '(created)'],
+        keyId: 'https://example.com/key/1',
+        signature: 'mockSignature',
+        created
+      });
+      authz.should.be.a('string');
+      authz.should.equal('Signature keyId="https://example.com/key/1",' +
+        'headers="date host (request-target) (created)",' +
+        `signature="mockSignature",created="${created}"`);
+    });
+    it('header with string (created)', () => {
+      const created = String(Math.floor(Date.now() / 1000));
+      const authz = httpSignatureHeader.createAuthzHeader({
+        includeHeaders: ['date', 'host', '(request-target)', '(created)'],
+        keyId: 'https://example.com/key/1',
+        signature: 'mockSignature',
+        created
+      });
+      authz.should.be.a('string');
+      authz.should.equal('Signature keyId="https://example.com/key/1",' +
+        'headers="date host (request-target) (created)",' +
+        `signature="mockSignature",created="${created}"`);
+    });
+    it('should throw if (created) is not a unix timestamp', () => {
+      const created = 'invalid-date-time';
+      let error = null;
+      let result = null;
+      try {
+        result = httpSignatureHeader.createAuthzHeader({
+          includeHeaders: ['date', 'host', '(request-target)', '(created)'],
+          keyId: 'https://example.com/key/1',
+          signature: 'mockSignature',
+          created
+        });
+      } catch(e) {
+        error = e;
+      }
+      expect(result).to.be.null;
+      expect(error).to.not.be.null;
+      error.message.should.equal(
+        '"created" must be a UNIX timestamp or JavaScript Date.');
+    });
+    it('header with integer (expires)', () => {
+      const expires = Math.floor(Date.now() / 1000);
+      const authz = httpSignatureHeader.createAuthzHeader({
+        includeHeaders: ['date', 'host', '(request-target)', '(expires)'],
+        keyId: 'https://example.com/key/1',
+        signature: 'mockSignature',
+        expires
+      });
+      authz.should.be.a('string');
+      authz.should.equal('Signature keyId="https://example.com/key/1",' +
+        'headers="date host (request-target) (expires)",' +
+        `signature="mockSignature",expires="${expires}"`);
+    });
+    it('header with string (expires)', () => {
+      const expires = String(Math.floor(Date.now() / 1000));
+      const authz = httpSignatureHeader.createAuthzHeader({
+        includeHeaders: ['date', 'host', '(request-target)', '(expires)'],
+        keyId: 'https://example.com/key/1',
+        signature: 'mockSignature',
+        expires
+      });
+      authz.should.be.a('string');
+      authz.should.equal('Signature keyId="https://example.com/key/1",' +
+        'headers="date host (request-target) (expires)",' +
+        `signature="mockSignature",expires="${expires}"`);
+    });
+    it('should throw if (expires) is not a unix timestamp', () => {
+      const expires = 'invalid-date-time';
+      let error = null;
+      let result = null;
+      try {
+        result = httpSignatureHeader.createAuthzHeader({
+          includeHeaders: ['date', 'host', '(request-target)', '(expires)'],
+          keyId: 'https://example.com/key/1',
+          signature: 'mockSignature',
+          expires
+        });
+      } catch(e) {
+        error = e;
+      }
+      expect(result).to.be.null;
+      expect(error).to.not.be.null;
+      error.message.should.equal(
+        '"expires" must be a UNIX timestamp or JavaScript Date.');
+    });
+
   });
   describe.skip('parseRequest api', function() {
     const now = 3;

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -161,6 +161,28 @@ describe('http-signature', () => {
       error.message.should.equal(
         'Invalid created. Your created pseudo-header is in the future');
     });
+    it('rejects `(created)` that is not a unix timestamp', () => {
+      const date = 'not a date';
+      const requestOptions = {
+        headers: {},
+        created: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      let error = null;
+      let result = null;
+      try {
+        result = httpSignatureHeader.createSignatureString(
+          {includeHeaders:
+            ['host', '(created)', '(request-target)'], requestOptions});
+      } catch(e) {
+        error = e;
+      }
+      expect(result, 'result should not exist').to.be.null;
+      expect(error, 'error should exist').to.not.be.null;
+      error.message.should.equal(
+        '"created" must be a UNIX timestamp or JavaScript Date.');
+    });
     it('convert Date objects to unix timestamps', () => {
       const date = new Date();
       const timestamp = Math.round(date.getTime() / 1000);
@@ -213,6 +235,28 @@ describe('http-signature', () => {
       expect(result, 'result should not exist').to.be.null;
       expect(error, 'error should exist').to.not.be.null;
       error.message.should.equal('Your signature has expired.');
+    });
+    it('rejects `(expires)` that is not a unix timestamp', () => {
+      const date = 'not a date';
+      const requestOptions = {
+        headers: {},
+        expires: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      let error = null;
+      let result = null;
+      try {
+        result = httpSignatureHeader.createSignatureString(
+          {includeHeaders:
+            ['host', '(expires)', '(request-target)'], requestOptions});
+      } catch(e) {
+        error = e;
+      }
+      expect(result, 'result should not exist').to.be.null;
+      expect(error, 'error should exist').to.not.be.null;
+      error.message.should.equal(
+        '"expires" must be a UNIX timestamp or JavaScript Date.');
     });
     it('properly encodes `(key-id)` with an iri', () => {
       const iri = 'https://example.com/key.pub';

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -270,12 +270,10 @@ describe('http-signature', () => {
         method: 'GET',
         url: 'https://example.com:18443/1/2/3',
       };
-      const stringToSign = httpSignatureHeader.parseRequest(
-        {includeHeaders:
-          ['host', '(created)', '(request-target)'], requestOptions});
-      stringToSign.should.equal(
-        `host: example.com:18443\n(created): ${date}\n` +
-        `(request-target): get /1/2/3`);
+      const expectedHeaders = ['host', '(created)', '(request-target)'];
+      const parsed = httpSignatureHeader.parseRequest(
+        requestOptions, {headers: expectedHeaders, now});
+      console.log({parsed});
     });
     it('properly encodes `(created)` as a string', () => {
       const date = String(Math.floor(Date.now() / 1000));

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -368,7 +368,7 @@ describe('http-signature', () => {
     });
     it('properly encodes `(created)` as a string', () => {
       const date = String(Math.floor(Date.now() / 1000));
-      const requestOptions = {
+      const request = {
         headers: {},
         created: date,
         method: 'GET',

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2020 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -139,6 +139,21 @@ describe('http-signature', () => {
         `host: example.com:18443\n(created): ${date}\n` +
         `(request-target): get /1/2/3`);
     });
+    it('properly encodes `(created)` as a string', () => {
+      const date = String(Math.round(Date.now() / 1000));
+      const requestOptions = {
+        headers: {},
+        created: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const stringToSign = httpSignatureHeader.createSignatureString(
+        {includeHeaders:
+          ['host', '(created)', '(request-target)'], requestOptions});
+      stringToSign.should.equal(
+        `host: example.com:18443\n(created): ${date}\n` +
+        `(request-target): get /1/2/3`);
+    });
     it('rejects `(created)` in the future', () => {
       const date = Math.round(Date.now() / 1000) + 2000;
       const requestOptions = {
@@ -202,6 +217,21 @@ describe('http-signature', () => {
 
     it('properly encodes `(expires)` with a timestamp', () => {
       const date = Math.round(Date.now() / 1000) + 120;
+      const requestOptions = {
+        headers: {},
+        expires: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const stringToSign = httpSignatureHeader.createSignatureString(
+        {includeHeaders:
+          ['host', '(expires)', '(request-target)'], requestOptions});
+      stringToSign.should.equal(
+        `host: example.com:18443\n(expires): ${date}\n` +
+        `(request-target): get /1/2/3`);
+    });
+    it('properly encodes `(expires)` as a string', () => {
+      const date = String(Math.round(Date.now() / 1000) + 120);
       const requestOptions = {
         headers: {},
         expires: date,

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -125,7 +125,7 @@ describe('http-signature', () => {
     });
 
     it('properly encodes `(created)` with a timestamp', () => {
-      const date = Math.floor(Date.now() / 1000);
+      const date = Math.ceil(Date.now() / 1000);
       const requestOptions = {
         headers: {},
         created: date,
@@ -140,7 +140,7 @@ describe('http-signature', () => {
         `(request-target): get /1/2/3`);
     });
     it('properly encodes `(created)` as a string', () => {
-      const date = String(Math.floor(Date.now() / 1000));
+      const date = String(Math.ceil(Date.now() / 1000));
       const requestOptions = {
         headers: {},
         created: date,
@@ -200,7 +200,7 @@ describe('http-signature', () => {
     });
     it('convert Date objects to unix timestamps', () => {
       const date = new Date();
-      const timestamp = Math.floor(date.getTime() / 1000);
+      const timestamp = Math.ceil(date.getTime() / 1000);
       const requestOptions = {
         headers: {},
         created: date,
@@ -216,7 +216,7 @@ describe('http-signature', () => {
     });
 
     it('properly encodes `(expires)` with a timestamp', () => {
-      const date = Math.ceil(Date.now() / 1000) + 120;
+      const date = Math.floor(Date.now() / 1000) + 120;
       const requestOptions = {
         headers: {},
         expires: date,
@@ -231,7 +231,7 @@ describe('http-signature', () => {
         `(request-target): get /1/2/3`);
     });
     it('properly encodes `(expires)` as a string', () => {
-      const date = String(Math.ceil(Date.now() / 1000) + 120);
+      const date = String(Math.floor(Date.now() / 1000) + 120);
       const requestOptions = {
         headers: {},
         expires: date,
@@ -246,7 +246,7 @@ describe('http-signature', () => {
         `(request-target): get /1/2/3`);
     });
     it('rejects `(expires)` in the past', () => {
-      const date = Math.ceil(Date.now() / 1000) - 120;
+      const date = Math.floor(Date.now() / 1000) - 120;
       const requestOptions = {
         headers: {},
         expires: date,

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -363,7 +363,7 @@ describe('http-signature', () => {
       };
       const expectedHeaders = ['host', '(created)', '(request-target)'];
       const parsed = httpSignatureHeader.parseRequest(
-        requestOptions, {headers: expectedHeaders, now});
+        request, {headers: expectedHeaders, now});
       console.log({parsed});
     });
     it('properly encodes `(created)` as a string', () => {
@@ -374,27 +374,25 @@ describe('http-signature', () => {
         method: 'GET',
         url: 'https://example.com:18443/1/2/3',
       };
-      const stringToSign = httpSignatureHeader.parseRequest(
-        {includeHeaders:
-          ['host', '(created)', '(request-target)'], ...request});
-      stringToSign.should.equal(
-        `host: example.com:18443\n(created): ${date}\n` +
-        `(request-target): get /1/2/3`);
+      const expectedHeaders = ['host', '(created)', '(request-target)'];
+      const parsed = httpSignatureHeader.parseRequest(
+        request, {headers: expectedHeaders, now});
+      console.log({parsed});
     });
     it('rejects `(created)` in the future', () => {
       const date = Math.floor(Date.now() / 1000) + 2000;
-      const requestOptions = {
+      const request = {
         headers: {},
         created: date,
         method: 'GET',
         url: 'https://example.com:18443/1/2/3',
       };
+      const expectedHeaders = ['host', '(created)', '(request-target)'];
       let error = null;
       let result = null;
       try {
         result = httpSignatureHeader.parseRequest(
-          {includeHeaders:
-            ['host', '(created)', '(request-target)'], requestOptions});
+          request, {headers: expectedHeaders, now});
       } catch(e) {
         error = e;
       }
@@ -405,18 +403,18 @@ describe('http-signature', () => {
     });
     it('rejects `(created)` that is not a unix timestamp', () => {
       const date = 'not a date';
-      const requestOptions = {
+      const request = {
         headers: {},
         created: date,
         method: 'GET',
         url: 'https://example.com:18443/1/2/3',
       };
+      const expectedHeaders = ['host', '(created)', '(request-target)'];
       let error = null;
       let result = null;
       try {
         result = httpSignatureHeader.parseRequest(
-          {includeHeaders:
-            ['host', '(created)', '(request-target)'], requestOptions});
+          request, {headers: expectedHeaders, now});
       } catch(e) {
         error = e;
       }
@@ -425,67 +423,61 @@ describe('http-signature', () => {
       error.message.should.equal(
         '"created" must be a UNIX timestamp or JavaScript Date.');
     });
-    it('convert Date objects to unix timestamps', () => {
+    it('convert (created) Date objects to unix timestamps', () => {
       const date = new Date();
       const timestamp = Math.floor(date.getTime() / 1000);
-      const requestOptions = {
+      const request = {
         headers: {},
         created: date,
         method: 'GET',
         url: 'https://example.com:18443/1/2/3',
       };
-      const stringToSign = httpSignatureHeader.parseRequest(
-        {includeHeaders:
-          ['host', '(created)', '(request-target)'], requestOptions});
-      stringToSign.should.equal(
-        `host: example.com:18443\n(created): ${timestamp}\n` +
-        `(request-target): get /1/2/3`);
+      const expectedHeaders = ['host', '(created)', '(request-target)'];
+      const parsed = httpSignatureHeader.parseRequest(
+        request, {headers: expectedHeaders, now});
+      console.log({parsed});
     });
 
     it('properly encodes `(expires)` with a timestamp', () => {
       const date = Math.floor(Date.now() / 1000) + 120;
-      const requestOptions = {
+      const request = {
         headers: {},
         expires: date,
         method: 'GET',
         url: 'https://example.com:18443/1/2/3',
       };
-      const stringToSign = httpSignatureHeader.parseRequest(
-        {includeHeaders:
-          ['host', '(expires)', '(request-target)'], requestOptions});
-      stringToSign.should.equal(
-        `host: example.com:18443\n(expires): ${date}\n` +
-        `(request-target): get /1/2/3`);
+      const expectedHeaders = ['host', '(expires)', '(request-target)'];
+      const parsed = httpSignatureHeader.parseRequest(
+        request, {headers: expectedHeaders, now});
+      console.log({parsed});
     });
     it('properly encodes `(expires)` as a string', () => {
       const date = String(Math.floor(Date.now() / 1000) + 120);
-      const requestOptions = {
+      const request = {
         headers: {},
         expires: date,
         method: 'GET',
         url: 'https://example.com:18443/1/2/3',
       };
-      const stringToSign = httpSignatureHeader.parseRequest(
-        {includeHeaders:
-          ['host', '(expires)', '(request-target)'], requestOptions});
-      stringToSign.should.equal(
-        `host: example.com:18443\n(expires): ${date}\n` +
-        `(request-target): get /1/2/3`);
+      const expectedHeaders = ['host', '(expires)', '(request-target)'];
+      const parsed = httpSignatureHeader.parseRequest(
+        request, {headers: expectedHeaders, now});
+      console.log({parsed});
     });
     it('rejects `(expires)` in the past', () => {
       const date = Math.floor(Date.now() / 1000) - 120;
-      const requestOptions = {
+      const request = {
         headers: {},
         expires: date,
         method: 'GET',
         url: 'https://example.com:18443/1/2/3',
       };
+      const expectedHeaders = ['host', '(expires)', '(request-target)'];
       let error = null;
       let result = null;
       try {
         result = httpSignatureHeader.parseRequest(
-          {includeHeaders:
-            ['host', '(expires)', '(request-target)'], requestOptions});
+          request, {headers: expectedHeaders, now});
       } catch(e) {
         error = e;
       }
@@ -495,18 +487,18 @@ describe('http-signature', () => {
     });
     it('rejects `(expires)` that is not a unix timestamp', () => {
       const date = 'not a date';
-      const requestOptions = {
+      const request = {
         headers: {},
         expires: date,
         method: 'GET',
         url: 'https://example.com:18443/1/2/3',
       };
+      const expectedHeaders = ['host', '(expires)', '(request-target)'];
       let error = null;
       let result = null;
       try {
         result = httpSignatureHeader.parseRequest(
-          {includeHeaders:
-            ['host', '(expires)', '(request-target)'], requestOptions});
+          request, {headers: expectedHeaders, now});
       } catch(e) {
         error = e;
       }

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -376,7 +376,7 @@ describe('http-signature', () => {
       };
       const stringToSign = httpSignatureHeader.parseRequest(
         {includeHeaders:
-          ['host', '(created)', '(request-target)'], requestOptions});
+          ['host', '(created)', '(request-target)'], ...request});
       stringToSign.should.equal(
         `host: example.com:18443\n(created): ${date}\n` +
         `(request-target): get /1/2/3`);

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -537,7 +537,9 @@ describe('http-signature', () => {
       const request = {
         headers: {
           host: 'example.com:18443',
-          date: new Date(expires),
+          date: new Date(now * 1000),
+          // convert the unix time to milliseconds for the header
+          expires: new Date(Number(expires) * 1000),
           authorization
         },
         expires,
@@ -563,7 +565,9 @@ describe('http-signature', () => {
       const request = {
         headers: {
           host: 'example.com:18443',
-          date: new Date(Number(expires)),
+          date: new Date(now * 1000),
+          // convert the unix time to milliseconds for the header
+          expires: new Date(Number(expires) * 1000),
           authorization
         },
         expires,

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -696,9 +696,9 @@ describe('http-signature', () => {
       expect(error, 'error should exist').to.not.be.null;
       error.message.should.equal('The request has expired.');
     });
-    it.skip('rejects if skew is greater then clockSkew', () => {
-      const _now = 1000;
-      const date = _now - 300;
+    it('rejects if skew is greater then clockSkew', () => {
+      const _now = 1603386114;
+      const date = _now - 350;
       const authorization = 'Signature keyId="https://example.com/key/1",' +
         'headers="x-date host (request-target)",' +
         `signature="mockSignature"`;
@@ -722,7 +722,34 @@ describe('http-signature', () => {
       }
       expect(result, 'result should not exist').to.be.null;
       expect(error, 'error should exist').to.not.be.null;
-      error.message.should.equal('The request has expired.');
+      error.message.should.equal('Clock skew of 350s was greater than 300s');
+    });
+    it('rejects if signature is missing from AuthzHeader', () => {
+      const _now = 1000;
+      const date = _now - 300;
+      const authorization = 'Signature keyId="https://example.com/key/1",' +
+        'headers="x-date host (request-target)",';
+      const request = {
+        headers: {
+          host: 'example.com:18443',
+          'x-date': new Date(date * 1000),
+          authorization
+        },
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const expectedHeaders = ['host', '(request-target)'];
+      let error = null;
+      let result = null;
+      try {
+        result = httpSignatureHeader.parseRequest(
+          request, {headers: expectedHeaders, now: _now});
+      } catch(e) {
+        error = e;
+      }
+      expect(result, 'result should not exist').to.be.null;
+      expect(error, 'error should exist').to.not.be.null;
+      error.message.should.equal('signature was not specified');
     });
   });
 });

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -355,7 +355,7 @@ describe('http-signature', () => {
     const now = 3;
     it('properly encodes `(created)` with a timestamp', () => {
       const date = Math.floor(Date.now() / 1000);
-      const requestOptions = {
+      const request = {
         headers: {},
         created: date,
         method: 'GET',

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -159,7 +159,7 @@ describe('http-signature', () => {
       expect(result, 'result should not exist').to.be.null;
       expect(error, 'error should exist').to.not.be.null;
       error.message.should.equal(
-        'Invalid created. Your created psuedo-header is in the future');
+        'Invalid created. Your created pseudo-header is in the future');
     });
     it('convert Date objects to unix timestamps', () => {
       const date = new Date();

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -124,170 +124,6 @@ describe('http-signature', () => {
         `host: example.com:18443\ndate: ${date}\nzero: `);
     });
 
-    it('properly encodes `(created)` with a timestamp', () => {
-      const date = Math.ceil(Date.now() / 1000);
-      const requestOptions = {
-        headers: {},
-        created: date,
-        method: 'GET',
-        url: 'https://example.com:18443/1/2/3',
-      };
-      const stringToSign = httpSignatureHeader.createSignatureString(
-        {includeHeaders:
-          ['host', '(created)', '(request-target)'], requestOptions});
-      stringToSign.should.equal(
-        `host: example.com:18443\n(created): ${date}\n` +
-        `(request-target): get /1/2/3`);
-    });
-    it('properly encodes `(created)` as a string', () => {
-      const date = String(Math.ceil(Date.now() / 1000));
-      const requestOptions = {
-        headers: {},
-        created: date,
-        method: 'GET',
-        url: 'https://example.com:18443/1/2/3',
-      };
-      const stringToSign = httpSignatureHeader.createSignatureString(
-        {includeHeaders:
-          ['host', '(created)', '(request-target)'], requestOptions});
-      stringToSign.should.equal(
-        `host: example.com:18443\n(created): ${date}\n` +
-        `(request-target): get /1/2/3`);
-    });
-    it('rejects `(created)` in the future', () => {
-      const date = Math.ceil(Date.now() / 1000) + 2000;
-      const requestOptions = {
-        headers: {},
-        created: date,
-        method: 'GET',
-        url: 'https://example.com:18443/1/2/3',
-      };
-      let error = null;
-      let result = null;
-      try {
-        result = httpSignatureHeader.createSignatureString(
-          {includeHeaders:
-            ['host', '(created)', '(request-target)'], requestOptions});
-      } catch(e) {
-        error = e;
-      }
-      expect(result, 'result should not exist').to.be.null;
-      expect(error, 'error should exist').to.not.be.null;
-      error.message.should.equal(
-        'Invalid created. Your created pseudo-header is in the future');
-    });
-    it('rejects `(created)` that is not a unix timestamp', () => {
-      const date = 'not a date';
-      const requestOptions = {
-        headers: {},
-        created: date,
-        method: 'GET',
-        url: 'https://example.com:18443/1/2/3',
-      };
-      let error = null;
-      let result = null;
-      try {
-        result = httpSignatureHeader.createSignatureString(
-          {includeHeaders:
-            ['host', '(created)', '(request-target)'], requestOptions});
-      } catch(e) {
-        error = e;
-      }
-      expect(result, 'result should not exist').to.be.null;
-      expect(error, 'error should exist').to.not.be.null;
-      error.message.should.equal(
-        '"created" must be a UNIX timestamp or JavaScript Date.');
-    });
-    it('convert Date objects to unix timestamps', () => {
-      const date = new Date();
-      const timestamp = Math.ceil(date.getTime() / 1000);
-      const requestOptions = {
-        headers: {},
-        created: date,
-        method: 'GET',
-        url: 'https://example.com:18443/1/2/3',
-      };
-      const stringToSign = httpSignatureHeader.createSignatureString(
-        {includeHeaders:
-          ['host', '(created)', '(request-target)'], requestOptions});
-      stringToSign.should.equal(
-        `host: example.com:18443\n(created): ${timestamp}\n` +
-        `(request-target): get /1/2/3`);
-    });
-
-    it('properly encodes `(expires)` with a timestamp', () => {
-      const date = Math.floor(Date.now() / 1000) + 120;
-      const requestOptions = {
-        headers: {},
-        expires: date,
-        method: 'GET',
-        url: 'https://example.com:18443/1/2/3',
-      };
-      const stringToSign = httpSignatureHeader.createSignatureString(
-        {includeHeaders:
-          ['host', '(expires)', '(request-target)'], requestOptions});
-      stringToSign.should.equal(
-        `host: example.com:18443\n(expires): ${date}\n` +
-        `(request-target): get /1/2/3`);
-    });
-    it('properly encodes `(expires)` as a string', () => {
-      const date = String(Math.floor(Date.now() / 1000) + 120);
-      const requestOptions = {
-        headers: {},
-        expires: date,
-        method: 'GET',
-        url: 'https://example.com:18443/1/2/3',
-      };
-      const stringToSign = httpSignatureHeader.createSignatureString(
-        {includeHeaders:
-          ['host', '(expires)', '(request-target)'], requestOptions});
-      stringToSign.should.equal(
-        `host: example.com:18443\n(expires): ${date}\n` +
-        `(request-target): get /1/2/3`);
-    });
-    it('rejects `(expires)` in the past', () => {
-      const date = Math.floor(Date.now() / 1000) - 120;
-      const requestOptions = {
-        headers: {},
-        expires: date,
-        method: 'GET',
-        url: 'https://example.com:18443/1/2/3',
-      };
-      let error = null;
-      let result = null;
-      try {
-        result = httpSignatureHeader.createSignatureString(
-          {includeHeaders:
-            ['host', '(expires)', '(request-target)'], requestOptions});
-      } catch(e) {
-        error = e;
-      }
-      expect(result, 'result should not exist').to.be.null;
-      expect(error, 'error should exist').to.not.be.null;
-      error.message.should.equal('Your signature has expired.');
-    });
-    it('rejects `(expires)` that is not a unix timestamp', () => {
-      const date = 'not a date';
-      const requestOptions = {
-        headers: {},
-        expires: date,
-        method: 'GET',
-        url: 'https://example.com:18443/1/2/3',
-      };
-      let error = null;
-      let result = null;
-      try {
-        result = httpSignatureHeader.createSignatureString(
-          {includeHeaders:
-            ['host', '(expires)', '(request-target)'], requestOptions});
-      } catch(e) {
-        error = e;
-      }
-      expect(result, 'result should not exist').to.be.null;
-      expect(error, 'error should exist').to.not.be.null;
-      error.message.should.equal(
-        '"expires" must be a UNIX timestamp or JavaScript Date.');
-    });
     it('properly encodes `(key-id)` with an iri', () => {
       const iri = 'https://example.com/key.pub';
       const requestOptions = {
@@ -422,6 +258,173 @@ describe('http-signature', () => {
       authz.should.equal('Signature keyId="https://example.com/key/1",' +
         'headers="date host (request-target)",' +
         'signature="mockSignature"');
+    });
+  });
+  describe.skip('parseRequest api', function() {
+    const now = 3;
+    it('properly encodes `(created)` with a timestamp', () => {
+      const date = Math.floor(Date.now() / 1000);
+      const requestOptions = {
+        headers: {},
+        created: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const stringToSign = httpSignatureHeader.parseRequest(
+        {includeHeaders:
+          ['host', '(created)', '(request-target)'], requestOptions});
+      stringToSign.should.equal(
+        `host: example.com:18443\n(created): ${date}\n` +
+        `(request-target): get /1/2/3`);
+    });
+    it('properly encodes `(created)` as a string', () => {
+      const date = String(Math.floor(Date.now() / 1000));
+      const requestOptions = {
+        headers: {},
+        created: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const stringToSign = httpSignatureHeader.parseRequest(
+        {includeHeaders:
+          ['host', '(created)', '(request-target)'], requestOptions});
+      stringToSign.should.equal(
+        `host: example.com:18443\n(created): ${date}\n` +
+        `(request-target): get /1/2/3`);
+    });
+    it('rejects `(created)` in the future', () => {
+      const date = Math.floor(Date.now() / 1000) + 2000;
+      const requestOptions = {
+        headers: {},
+        created: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      let error = null;
+      let result = null;
+      try {
+        result = httpSignatureHeader.parseRequest(
+          {includeHeaders:
+            ['host', '(created)', '(request-target)'], requestOptions});
+      } catch(e) {
+        error = e;
+      }
+      expect(result, 'result should not exist').to.be.null;
+      expect(error, 'error should exist').to.not.be.null;
+      error.message.should.equal(
+        'Invalid created. Your created pseudo-header is in the future');
+    });
+    it('rejects `(created)` that is not a unix timestamp', () => {
+      const date = 'not a date';
+      const requestOptions = {
+        headers: {},
+        created: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      let error = null;
+      let result = null;
+      try {
+        result = httpSignatureHeader.parseRequest(
+          {includeHeaders:
+            ['host', '(created)', '(request-target)'], requestOptions});
+      } catch(e) {
+        error = e;
+      }
+      expect(result, 'result should not exist').to.be.null;
+      expect(error, 'error should exist').to.not.be.null;
+      error.message.should.equal(
+        '"created" must be a UNIX timestamp or JavaScript Date.');
+    });
+    it('convert Date objects to unix timestamps', () => {
+      const date = new Date();
+      const timestamp = Math.floor(date.getTime() / 1000);
+      const requestOptions = {
+        headers: {},
+        created: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const stringToSign = httpSignatureHeader.parseRequest(
+        {includeHeaders:
+          ['host', '(created)', '(request-target)'], requestOptions});
+      stringToSign.should.equal(
+        `host: example.com:18443\n(created): ${timestamp}\n` +
+        `(request-target): get /1/2/3`);
+    });
+
+    it('properly encodes `(expires)` with a timestamp', () => {
+      const date = Math.floor(Date.now() / 1000) + 120;
+      const requestOptions = {
+        headers: {},
+        expires: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const stringToSign = httpSignatureHeader.parseRequest(
+        {includeHeaders:
+          ['host', '(expires)', '(request-target)'], requestOptions});
+      stringToSign.should.equal(
+        `host: example.com:18443\n(expires): ${date}\n` +
+        `(request-target): get /1/2/3`);
+    });
+    it('properly encodes `(expires)` as a string', () => {
+      const date = String(Math.floor(Date.now() / 1000) + 120);
+      const requestOptions = {
+        headers: {},
+        expires: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const stringToSign = httpSignatureHeader.parseRequest(
+        {includeHeaders:
+          ['host', '(expires)', '(request-target)'], requestOptions});
+      stringToSign.should.equal(
+        `host: example.com:18443\n(expires): ${date}\n` +
+        `(request-target): get /1/2/3`);
+    });
+    it('rejects `(expires)` in the past', () => {
+      const date = Math.floor(Date.now() / 1000) - 120;
+      const requestOptions = {
+        headers: {},
+        expires: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      let error = null;
+      let result = null;
+      try {
+        result = httpSignatureHeader.parseRequest(
+          {includeHeaders:
+            ['host', '(expires)', '(request-target)'], requestOptions});
+      } catch(e) {
+        error = e;
+      }
+      expect(result, 'result should not exist').to.be.null;
+      expect(error, 'error should exist').to.not.be.null;
+      error.message.should.equal('Your signature has expired.');
+    });
+    it('rejects `(expires)` that is not a unix timestamp', () => {
+      const date = 'not a date';
+      const requestOptions = {
+        headers: {},
+        expires: date,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      let error = null;
+      let result = null;
+      try {
+        result = httpSignatureHeader.parseRequest(
+          {includeHeaders:
+            ['host', '(expires)', '(request-target)'], requestOptions});
+      } catch(e) {
+        error = e;
+      }
+      expect(result, 'result should not exist').to.be.null;
+      expect(error, 'error should exist').to.not.be.null;
+      error.message.should.equal(
+        '"expires" must be a UNIX timestamp or JavaScript Date.');
     });
   });
 });

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -125,7 +125,7 @@ describe('http-signature', () => {
     });
 
     it('properly encodes `(created)` with a timestamp', () => {
-      const date = Math.round(Date.now() / 1000);
+      const date = Math.floor(Date.now() / 1000);
       const requestOptions = {
         headers: {},
         created: date,
@@ -140,7 +140,7 @@ describe('http-signature', () => {
         `(request-target): get /1/2/3`);
     });
     it('properly encodes `(created)` as a string', () => {
-      const date = String(Math.round(Date.now() / 1000));
+      const date = String(Math.floor(Date.now() / 1000));
       const requestOptions = {
         headers: {},
         created: date,
@@ -155,7 +155,7 @@ describe('http-signature', () => {
         `(request-target): get /1/2/3`);
     });
     it('rejects `(created)` in the future', () => {
-      const date = Math.round(Date.now() / 1000) + 2000;
+      const date = Math.ceil(Date.now() / 1000) + 2000;
       const requestOptions = {
         headers: {},
         created: date,
@@ -200,7 +200,7 @@ describe('http-signature', () => {
     });
     it('convert Date objects to unix timestamps', () => {
       const date = new Date();
-      const timestamp = Math.round(date.getTime() / 1000);
+      const timestamp = Math.floor(date.getTime() / 1000);
       const requestOptions = {
         headers: {},
         created: date,
@@ -216,7 +216,7 @@ describe('http-signature', () => {
     });
 
     it('properly encodes `(expires)` with a timestamp', () => {
-      const date = Math.round(Date.now() / 1000) + 120;
+      const date = Math.ceil(Date.now() / 1000) + 120;
       const requestOptions = {
         headers: {},
         expires: date,
@@ -231,7 +231,7 @@ describe('http-signature', () => {
         `(request-target): get /1/2/3`);
     });
     it('properly encodes `(expires)` as a string', () => {
-      const date = String(Math.round(Date.now() / 1000) + 120);
+      const date = String(Math.ceil(Date.now() / 1000) + 120);
       const requestOptions = {
         headers: {},
         expires: date,
@@ -246,7 +246,7 @@ describe('http-signature', () => {
         `(request-target): get /1/2/3`);
     });
     it('rejects `(expires)` in the past', () => {
-      const date = Math.round(Date.now() / 1000) - 120;
+      const date = Math.ceil(Date.now() / 1000) - 120;
       const requestOptions = {
         headers: {},
         expires: date,

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -365,6 +365,32 @@ describe('http-signature', () => {
     };
     // tests occur 3 seconds after the epoch
     const now = 3;
+    it('should use Date.now() when now is not specified', () => {
+      const created = Math.floor(Date.now() / 1000);
+      const authorization = 'Signature keyId="https://example.com/key/1",' +
+        'headers="date host (request-target) (created)",' +
+        `signature="mockSignature",created="${created}"`;
+      const request = {
+        headers: {
+          host: 'example.com:18443',
+          date: new Date().toUTCString(),
+          authorization
+        },
+        created,
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const expectedHeaders = ['host', '(created)', '(request-target)'];
+      const parsed = httpSignatureHeader.parseRequest(
+        request, {headers: expectedHeaders});
+      expect(parsed, 'expected the parsing result to be an object').
+        to.be.an('object');
+      shouldBeParsed(parsed);
+      expect(parsed.params.created, 'expected created to be a string').
+        to.be.a('string');
+      parsed.params.created.should.equal(String(created));
+      parsed.signingString.should.contain(`(created): ${created}`);
+    });
     it('properly encodes `(created)` with a timestamp', () => {
       const created = 1;
       const authorization = 'Signature keyId="https://example.com/key/1",' +

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -751,5 +751,60 @@ describe('http-signature', () => {
       expect(error, 'error should exist').to.not.be.null;
       error.message.should.equal('signature was not specified');
     });
+    it('rejects if schema is not Signature', () => {
+      const date = now - 1;
+      const authorization = 'NotSignature keyId="https://example.com/key/1",' +
+        'headers="x-date host (request-target)",' +
+        `signature="mockSignature"`;
+      const request = {
+        headers: {
+          host: 'example.com:18443',
+          'x-date': new Date(date * 1000),
+          authorization
+        },
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const expectedHeaders = ['host', '(request-target)'];
+      let error = null;
+      let result = null;
+      try {
+        result = httpSignatureHeader.parseRequest(
+          request, {headers: expectedHeaders, now});
+      } catch(e) {
+        error = e;
+      }
+      expect(result, 'result should not exist').to.be.null;
+      expect(error, 'error should exist').to.not.be.null;
+      error.message.should.equal('scheme was not "Signature"');
+    });
+    it('rejects if no keyId', () => {
+      const date = now - 1;
+      const authorization = 'Signature ' +
+        'headers="x-date host (request-target)",' +
+        `signature="mockSignature"`;
+      const request = {
+        headers: {
+          host: 'example.com:18443',
+          'x-date': new Date(date * 1000),
+          authorization
+        },
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const expectedHeaders = ['host', '(request-target)'];
+      let error = null;
+      let result = null;
+      try {
+        result = httpSignatureHeader.parseRequest(
+          request, {headers: expectedHeaders, now});
+      } catch(e) {
+        error = e;
+      }
+      expect(result, 'result should not exist').to.be.null;
+      expect(error, 'error should exist').to.not.be.null;
+      error.message.should.equal('keyId was not specified');
+    });
+
   });
 });


### PR DESCRIPTION
This corrects a bug so that the validators for created and expires convert unix time stamps to milliseconds then compare.

p.s. this validation could be moved into the actual library if wanted. right now it's in the binary only.

p.p.s **I noticed that our current use of http signatures is using javascript millisecond time strings which means if the created and expires validators are moved to the main library we will need to check each and every use of expires and created in existing projects especially in z caps.**

To reiterate this is might be a slightly larger bug than expected.

Normative statements WRT to this PR:


> "created"
>       RECOMMENDED.  The "created" parameter contains the signature's
>       Creation Time, expressed as the canonicalized value of the
>       "(created)" content identifier, as defined in Section 2.  If not
>       specified, the signature's Creation Time is undefined.  This
>       parameter is useful when signers are not capable of controlling
>       the "Date" HTTP Header such as when operating in certain web
>       browser environments.
> 
>    "expires"
>       OPTIONAL.  The "expires" parameter contains the signature's
>       Expiration Time, expressed as the canonicalized value of the
>       "(expires)" content identifier, as defined in Section 2.  If the
>       signature does not have an Expiration Time, this parameter "MUST"
>       be omitted.  If not specified, the signature's Expiration Time is
>       undefined.

> If the created Signature Parameter is not an integer or unix timestamp, an implementation MUST produce an error.

> If the expires Signature Parameter is not an integer or unix timestamp, an implementation MUST produce an error.

EDIT from the latest spec:


> 2.2.  Signature Creation Time
> 
>    The signature's Creation Time (Section 3.1) is identified by the
>    "(created)" identifier.
> 
>    Its canonicalized value is an Integer String containing the
>    signature's Creation Time expressed as the number of seconds since
>    the Epoch, as defined in Section 4.16
> 
> 
> 
> Backman, et al.          Expires 12 October 2020                [Page 8]
> 
>  
> Internet-Draft            Signing HTTP Messages               April 2020
> 
> 
>    (https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/
>    V1_chap04.html#tag_04_16) of [POSIX.1].
> 
>       |  The use of seconds since the Epoch to canonicalize a timestamp
>       |  simplifies processing and avoids timezone management required
>       |  by specifications such as [RFC3339].
> 

>    If Covered Content contains "(created)" and the signature's Creation
>    Time is undefined or the signature's Algorithm name starts with
>    "rsa", "hmac", or "ecdsa" an implementation MUST produce an error.

- [ ] we might not cover this

>    If Covered Content contains "(expires)" and the signature does not
>    have an Expiration Time or the signature's Algorithm name starts with
>    "rsa", "hmac", or "ecdsa" an implementation MUST produce an error.