### PR TITLE
Implement createDigestString() method.

### DIFF
--- a/bin/util.js
+++ b/bin/util.js
@@ -95,7 +95,7 @@ function validatePrivateKey(keyObj) {
  * @param {Array<string>} options.includeHeaders - Which headers
  * to use in the Signing String.
  *
- * @returns {Object} The response headers.
+ * @returns {object} The response headers.
 */
 async function createHttpSignatureRequest({
   algorithm = 'hs2019', privateKey, keyType,
@@ -103,7 +103,7 @@ async function createHttpSignatureRequest({
 }) {
   // get metadata from public key
   if(!keyType) {
-    throw new Error('Expected to recieve keyType');
+    throw new Error('Expected to receive keyType.');
   }
   requestOptions.headers = requestOptions.headers || {};
   if(!requestOptions.headers.date) {

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -1,0 +1,2 @@
+// WebCrypto polyfill
+module.exports = require('isomorphic-webcrypto');

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,8 +6,10 @@
  * Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
-
+const base64url = require('base64url');
+const crypto = require('./crypto');
 const env = require('./env');
+
 let assert;
 let Url;
 if(env.nodejs) {
@@ -214,6 +216,47 @@ function lowerCaseObjectKeys(obj) {
   }
   return newObject;
 }
+
+/**
+ * @param {string} data - String data (request body) to digest.
+ * @param {string} [algorithm] - Digest hash algorithm ('hs2019' or 'sha256').
+ * @param {boolean} [useMultihash=true] - Whether to encode digest string as
+ *   multihash, or an RFC3230 type value, like `Digest: SHA-256=...`.
+ *
+ * @returns {string}
+ */
+api.createDigestString = async (
+  {data, algorithm = 'sha256', useMultihash = true}) => {
+  const encodedData = new TextEncoder().encode(data);
+  let digest;
+
+  switch(algorithm) {
+    case 'sha256': {
+      digest = new Uint8Array(
+        await crypto.subtle.digest({name: 'SHA-256'}, encodedData));
+      break;
+    }
+    case 'hs2019': {
+      // todo: support hs2019 / SHA-512
+    }
+    default: {
+      throw new Error(`${algorithm} is not unsupported.`);
+    }
+  }
+
+  if(useMultihash) {
+    // format as multihash digest
+    // sha2-256: 0x12, length: 32 (0x20), digest value
+    const mh = new Uint8Array(34);
+    mh[0] = 0x12;
+    mh[1] = 0x20;
+    mh.set(digest, 2);
+    // encode multihash using multibase, base64url: `u`
+    return `mh=u${base64url.encode(mh)}`;
+  }
+
+  return `SHA-256=${base64url.toBase64(base64url.encode(digest))}`;
+};
 
 api.createSignatureString = ({includeHeaders, requestOptions} = {}) => {
   assert.object(requestOptions, 'requestOptions');

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   },
   "homepage": "https://github.com/digitalbazaar/http-signature-header#readme",
   "dependencies": {
-    "assert-plus": "^1.0.0"
+    "assert-plus": "^1.0.0",
+    "base64url": "^3.0.1",
+    "base64url-universal": "^1.1.0",
+    "isomorphic-webcrypto": "^2.3.2"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,16 @@ const HttpSignatureError = require('../lib/HttpSignatureError');
 
 describe('http-signature', () => {
 
+  describe('createDigestString', () => {
+    it('should create a digest of a given string', async () => {
+      const data = `{"hello": "world"}`;
+      const result = await httpSignatureHeader.
+        createDigestString({data, algorithm: 'sha256', useMultihash: false});
+      result.should
+        .equal('SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=');
+    });
+  });
+
   describe('createSignatureString API', () => {
     it('uses `date` header if specified', () => {
       const date = new Date().toUTCString();


### PR DESCRIPTION
Extracted from https://github.com/digitalbazaar/http-signature-zcap-invoke/blob/master/main.js#L35

WIP, todo:
- [ ] Find an isomorphic way to base64-encode strings (our `base64url-universal` does not expose non-url encoding)
- [ ] Find some test strings for multihash digest?
