### PR TITLE
Make algorithm default to `hs2019`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -169,7 +169,7 @@ api.createAuthzHeader = ({
   created,
   expires
 }) => {
-  assert.string(algorithm);
+  assert.optionalString(algorithm);
   assert.string(keyId);
   assert.arrayOfString(includeHeaders);
   assert.string(signature);

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,17 +162,19 @@ function extractPseudoHeaders(params, requestOptions) {
 }
 api.extractPseudoHeaders = extractPseudoHeaders;
 
-api.createAuthzHeader = (
-  {algorithm, includeHeaders, keyId, signature, created, expires}) => {
-  assert.optionalString(algorithm);
+api.createAuthzHeader = ({
+  algorithm = 'hs2019',
+  includeHeaders, keyId,
+  signature,
+  created,
+  expires
+}) => {
+  assert.string(algorithm);
   assert.string(keyId);
   assert.arrayOfString(includeHeaders);
   assert.string(signature);
 
-  const params = {keyId};
-  if(algorithm) {
-    params.algorithm = algorithm;
-  }
+  const params = {keyId, algorithm};
   params.headers = includeHeaders.join(' ');
   params.signature = signature;
   if(created !== undefined) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "cross-env": "^7.0.2",
-    "eslint": "^6.8.0",
+    "eslint": "^7.10.0",
     "eslint-config-digitalbazaar": "^2.0.0",
     "eslint-plugin-jsdoc": "^4.8.3",
     "mocha": "^6.0.0",


### PR DESCRIPTION
> 
>    "algorithm"
>       RECOMMENDED.  The "algorithm" parameter contains the name of the
>       signature's Algorithm, as registered in the HTTP Signature
>       Algorithms Registry defined by this document.  Verifiers MUST
>       determine the signature's Algorithm from the "keyId" parameter
>       rather than from "algorithm".  If "algorithm" is provided and
>       differs from or is incompatible with the algorithm or key material
>       identified by "keyId" (for example, "algorithm" has a value of
>       "rsa-sha256" but "keyId" identifies an EdDSA key), then
>       implementations MUST produce an error.  Implementers should note
>       that previous versions of this specification determined the
>       signature's Algorithm using the "algorithm" parameter only, and
>       thus could be utilized by attackers to expose security
>       vulnerabilities.  The default value for this parameter is
>       "hs2019".
https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00#section-4.1

Algorithm is not required, but defaults to `hs2019`


 
>        If the signature's Algorithm name does not start with "rsa",
>        "hmac", or "ecdsa", signers SHOULD include "(created)" and
>        "(request-target)" in the list.

- [ ] ensure we are adding `(created)` and `(request-target)` when algorithm is not one of the above. (I believe we are)

>   If the signature's Algorithm starts with "rsa", "hmac", or
>        "ecdsa", signers SHOULD include "date" and "(request-target)" in
>        the list.

- [ ] we don't cover this