### PR TITLE
Check for signature param in request.params.signature.

### DIFF
--- a/bin/util.js
+++ b/bin/util.js
@@ -180,12 +180,6 @@ exports.verify = async function(
     headers: includeHeaders
   };
   const request = httpSigs.parseRequest(requestOptions, options);
-  if(!request.params.signature) {
-    throw new Error('No signature parameter found in Authorization header');
-  }
-  if(!request.params.keyId) {
-    throw new Error('keyId is required for verification.');
-  }
   const signature = new Buffer(request.params.signature, 'base64');
   if(httpSignatureAlgorithm.hash) {
     httpSignatureAlgorithm.hash.update(canonicalizedString);

--- a/bin/util.js
+++ b/bin/util.js
@@ -180,13 +180,13 @@ exports.verify = async function(
     headers: includeHeaders
   };
   const request = httpSigs.parseRequest(requestOptions, options);
-  const signature = new Buffer(request.params.signature, 'base64');
-  if(!signature) {
+  if(!request.params.signature) {
     throw new Error('No signature parameter found in Authorization header');
   }
   if(!request.params.keyId) {
     throw new Error('keyId is required for verification.');
   }
+  const signature = new Buffer(request.params.signature, 'base64');
   if(httpSignatureAlgorithm.hash) {
     httpSignatureAlgorithm.hash.update(canonicalizedString);
     canonicalizedString = Buffer.from(


### PR DESCRIPTION
Should fix the signature parameter error:

https://github.com/digitalbazaar/http-signature-header/issues/20

I think this is a redundant check as we already throw in `parseRequest` when there is no `parsed.params.signature` so this is a draft PR as I'm wondering if I should drop this validator from the binary and use the one from the library instead. Also sorry about the low quality of code in the binary.

https://github.com/digitalbazaar/http-signature-header/blob/f88cf51531447569c91e0e01bbaadb92ba3aff64/lib/index.js#L301-L303

EDIT: THIS CAN WAIT TILL AFTER THE HOLIDAYS NO RUSH HERE.