### PR TITLE
Handling headers="" and expanded test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,20 @@
 
 ### Fixed
 - Pseudo-headers `created` & `expires` must be unix time stamps or js Dates.
+- hs2019 does not hash signature string before signing a signature string.
+
+### Changed
+- Library throws if the signature parameter headers is a zero-length string.
+- Library adds default `(created)` if no signature parameter header is present.
 
 ### Added
+- Support for version 12 of the HTTP signature specification.
 - Validators for `created` & `expires`.
 - Tests for `parseRequest`.
+- Tests for headers parameter order.
+- Tests for unrecognized parameters in a signature.
+- Jsdoc strings for library functions and methods.
+- Validation is algorithm specific in some cases.
 
 ## 1.3.1 - 2019-07-18
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -279,7 +279,11 @@ api.parseRequest = (request, options = {}) => {
   const authz = request.headers[authzHeaderName];
   // parse the signature returning an object
   const parsed = parseSignatureHeader(authz);
-
+  // throw if headers is a zero-length string
+  if(parsed.params.headers === '') {
+    throw new HttpSignatureError(
+      'headers parameter can not be a zero-length string', 'SyntaxError');
+  }
   // the signature parameter headers is optional and defaults to (created)
   if(!parsed.params.headers) {
     // latest spec (draft-ietf-httpbis-message-signatures-00) specifies this

--- a/lib/index.js
+++ b/lib/index.js
@@ -521,7 +521,8 @@ function validateDate(date, key) {
 }
 
 /**
- * Takes in an algorithm and the headers parameters from the signature.
+ * Ensures the given algorithm and the headers parameters from the signature
+ * are compatible with one another.
  *
  * @param {string} [algorithm=''] - The algorithm from the signature.
  * @param {Array<string>} [includeHeaders=[]] - The covered content from

--- a/lib/index.js
+++ b/lib/index.js
@@ -434,6 +434,10 @@ function _signingString({
   includeHeaders, headers, method,
   host, path, requestOptions, validate
 }) {
+  const {algorithm} = requestOptions;
+  // we need to check that the covered content
+  // if allowed by the algorithm
+  validateByAlgorithm(algorithm, includeHeaders);
   const result = [];
   for(const h of includeHeaders) {
     if(h === '(request-target)') {
@@ -514,6 +518,40 @@ function validateDate(date, key) {
   }
   throw new TypeError(
     `"${key}" must be a UNIX timestamp or JavaScript Date.`);
+}
+
+/**
+ * Takes in an algorithm and the headers parameters from the signature.
+ *
+ * @param {string} [algorithm=''] - The algorithm from the signature.
+ * @param {Array<string>} [includeHeaders=[]] - The covered content from
+ *   the signature.
+ *
+ * @throws - If the includeHeaders contains a header not allowed
+ *   by the algorithm.
+ *
+ * @returns {boolean} Is the algorithm valid?
+*/
+function validateByAlgorithm(algorithm = '', includeHeaders = []) {
+  // algorithm is optional so no need to check if not specified
+  if(!algorithm) {
+    return true;
+  }
+  // these 3 older algorithms can not use some pseudo-headers
+  const olderAlgorithms = [/$rsa/i, /$hmac/i, /$ecdsa/i];
+  for(const check of olderAlgorithms) {
+    if(check.test(algorithm)) {
+      if(includeHeaders.includes('(created)')) {
+        throw new HttpSignatureError(
+          `Algorithm ${algorithm} does not support (created)`, 'SyntaxError');
+      }
+      if(includeHeaders.includes('(expires)')) {
+        throw new HttpSignatureError(
+          `Algorithm ${algorithm} does not support (expires)`, 'SyntaxError');
+      }
+    }
+  }
+  return true;
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -436,7 +436,7 @@ function _signingString({
 }) {
   const {algorithm} = requestOptions;
   // we need to check that the covered content
-  // if allowed by the algorithm
+  // is allowed by the algorithm
   validateByAlgorithm(algorithm, includeHeaders);
   const result = [];
   for(const h of includeHeaders) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -546,11 +546,13 @@ function validateByAlgorithm(algorithm = '', includeHeaders = []) {
     if(check.test(algorithmStart)) {
       if(includeHeaders.includes('(created)')) {
         throw new HttpSignatureError(
-          `Algorithm ${algorithm} does not support (created)`, 'SyntaxError');
+          `Algorithm ${algorithm} does not support "(created)".`,
+          'SyntaxError');
       }
       if(includeHeaders.includes('(expires)')) {
         throw new HttpSignatureError(
-          `Algorithm ${algorithm} does not support (expires)`, 'SyntaxError');
+          `Algorithm ${algorithm} does not support "(expires)".`,
+          'SyntaxError');
       }
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -539,8 +539,11 @@ function validateByAlgorithm(algorithm = '', includeHeaders = []) {
   }
   // these 3 older algorithms can not use some pseudo-headers
   const olderAlgorithms = [/$rsa/i, /$hmac/i, /$ecdsa/i];
+  // in order to prevent an attack with an extremely long string
+  // we only use the first 5 characters after a trim
+  const algorithmStart = algorithm.trim().substr(0, 5);
   for(const check of olderAlgorithms) {
-    if(check.test(algorithm)) {
+    if(check.test(algorithmStart)) {
       if(includeHeaders.includes('(created)')) {
         throw new HttpSignatureError(
           `Algorithm ${algorithm} does not support (created)`, 'SyntaxError');

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,6 +162,22 @@ function extractPseudoHeaders(params, requestOptions) {
 }
 api.extractPseudoHeaders = extractPseudoHeaders;
 
+/**
+ * Creates an http-sig header for either a request or response.
+ *
+ * @param {object} options - Options to use.
+ * @param {string} [options.algorithm] - A HTTP Sig algorithm.
+ * @param {Array<string>} options.includeHeaders - Headers for the signature's
+ *   headers parameter.
+ * @param {string} options.keyId - The id of the key to verify with.
+ * @param {string} options.signature - A valid http signature.
+ * @param {string|number} [options.created] - A valid unix time stamp for
+ *   the signature parameter (created).
+ * @param {string|number} [options.expires] - A valid unix time stamp for
+ *  the signature parameter (expires).
+ *
+ * @returns {string} A valid http signature header.
+*/
 api.createAuthzHeader = (
   {algorithm, includeHeaders, keyId, signature, created, expires}) => {
   assert.optionalString(algorithm);

--- a/lib/index.js
+++ b/lib/index.js
@@ -527,8 +527,8 @@ function validateDate(date, key) {
  * @param {Array<string>} [includeHeaders=[]] - The covered content from
  *   the signature.
  *
- * @throws - If the includeHeaders contains a header not allowed
- *   by the algorithm.
+ * @throws {HttpSignatureError} - If the includeHeaders contains a header
+ *   not allowed by the algorithm.
  *
  * @returns {boolean} Is the algorithm valid?
 */
@@ -538,7 +538,7 @@ function validateByAlgorithm(algorithm = '', includeHeaders = []) {
     return true;
   }
   // these 3 older algorithms can not use some pseudo-headers
-  const olderAlgorithms = [/$rsa/i, /$hmac/i, /$ecdsa/i];
+  const olderAlgorithms = [/^rsa/i, /^hmac/i, /^ecdsa/i];
   // in order to prevent an attack with an extremely long string
   // we only use the first 5 characters after a trim
   const algorithmStart = algorithm.trim().substr(0, 5);

--- a/lib/index.js
+++ b/lib/index.js
@@ -282,7 +282,7 @@ api.parseRequest = (request, options = {}) => {
   // throw if headers is a zero-length string
   if(parsed.params.headers === '') {
     throw new HttpSignatureError(
-      'headers parameter can not be a zero-length string', 'SyntaxError');
+      'The "headers" parameter must not be a zero-length string.', 'SyntaxError');
   }
   // the signature parameter headers is optional and defaults to (created)
   if(!parsed.params.headers) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -282,7 +282,8 @@ api.parseRequest = (request, options = {}) => {
   // throw if headers is a zero-length string
   if(parsed.params.headers === '') {
     throw new HttpSignatureError(
-      'The "headers" parameter must not be a zero-length string.', 'SyntaxError');
+      'The "headers" parameter must not be a zero-length string.',
+      'SyntaxError');
   }
   // the signature parameter headers is optional and defaults to (created)
   if(!parsed.params.headers) {

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -169,6 +169,70 @@ describe('http-signature', () => {
         `(request-target): get /1/2/3`);
     });
 
+    const algorithms = ['rsa', 'hmac', 'ecdsa'];
+
+    for(const algorithm of algorithms) {
+      it(`properly encodes when using algorithm ${algorithm}`, () => {
+        const requestOptions = {
+          headers: {},
+          algorithm,
+          method: 'GET',
+          url: 'https://example.com:18443/1/2/3',
+        };
+        const includeHeaders = ['host', '(algorithm)', '(request-target)'];
+        const stringToSign = httpSignatureHeader.createSignatureString(
+          {includeHeaders, requestOptions});
+        stringToSign.should.equal(
+          `host: example.com:18443\n(algorithm): ${algorithm}\n` +
+        `(request-target): get /1/2/3`);
+      });
+
+      it('throws when `(created)` is used with algorithm ' + algorithm, () => {
+        const requestOptions = {
+          headers: {},
+          algorithm,
+          method: 'GET',
+          url: 'https://example.com:18443/1/2/3',
+        };
+        const includeHeaders = ['(created)', '(algorithm)', '(request-target)'];
+        let result;
+        let error;
+        try {
+          result = httpSignatureHeader.createSignatureString(
+            {includeHeaders, requestOptions});
+        } catch(e) {
+          error = e;
+        }
+        expect(result).to.be.undefined;
+        expect(error).to.not.be.undefined;
+        error.message.should.equal(
+          `Algorithm ${algorithm} does not support "(created)".`);
+      });
+
+      it('throws when `(expires)` is used with algorithm ' + algorithm, () => {
+        const requestOptions = {
+          headers: {},
+          algorithm,
+          method: 'GET',
+          url: 'https://example.com:18443/1/2/3',
+        };
+        const includeHeaders = ['(expires)', '(algorithm)', '(request-target)'];
+        let result;
+        let error;
+        try {
+          result = httpSignatureHeader.createSignatureString(
+            {includeHeaders, requestOptions});
+        } catch(e) {
+          error = e;
+        }
+        expect(result).to.be.undefined;
+        expect(error).to.not.be.undefined;
+        error.message.should.equal(
+          `Algorithm ${algorithm} does not support "(expires)".`);
+      });
+
+    }
+
     it('properly encodes a header with multiple values', () => {
       const date = new Date().toUTCString();
       const requestOptions = {

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -184,6 +184,31 @@ describe('http-signature', () => {
         `${date}\n(request-target): get /1/2/3`);
     });
 
+    it('properly encodes using header parameter order', () => {
+      const date = new Date().toUTCString();
+      const requestOptions = {
+        headers: {date},
+        method: 'GET',
+        url: 'https://example.com/1/2/3',
+      };
+      // 2 different signatures with the same parameters
+      // in a different order
+      const firstString = httpSignatureHeader.createSignatureString(
+        {includeHeaders: ['host', 'date', '(request-target)'],
+          requestOptions});
+      firstString.should.equal(
+        `host: example.com\ndate: ${date}\n` +
+        `(request-target): get /1/2/3`);
+      // the header parameters have the same value, but are in a different order
+      const secondString = httpSignatureHeader.createSignatureString(
+        {includeHeaders: ['(request-target)', 'host', 'date'],
+          requestOptions});
+      secondString.should.not.equal(firstString);
+      secondString.should.equal(
+        `(request-target): get /1/2/3\nhost: example.com\ndate: ` +
+        `${date}`);
+    });
+
     it('throws when an unknown header is specified', () => {
       const date = new Date().toUTCString();
       const requestOptions = {

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -909,7 +909,8 @@ describe('http-signature', () => {
       }
       expect(result, 'result should not exist').to.be.null;
       expect(error, 'error should exist').to.not.be.null;
-      error.message.should.equal('created was not in the request');
+      error.message.should.equal(
+        'headers parameter can not be a zero-length string');
     });
 
     it('should error if both created and headers are not set', () => {

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -391,6 +391,7 @@ describe('http-signature', () => {
 
   });
   describe('parseRequest api', function() {
+    // takes the result of parseRequest and tests it
     const shouldBeParsed = parsed => {
       parsed.should.have.property('params');
       parsed.params.should.be.an('object');
@@ -857,6 +858,30 @@ describe('http-signature', () => {
       parsed.params.created.should.equal(String(created));
       parsed.signingString.should.contain(`(created): ${created}`);
     });
+    it('should error if headers parameter is zero-length', () => {
+      const authorization = 'Signature keyId="https://example.com/key/1",' +
+        `headers="",signature="mockSignature"`;
+      const request = {
+        headers: {
+          host: 'example.com:18443',
+          authorization
+        },
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      let error = null;
+      let result = null;
+      try {
+        result = httpSignatureHeader.parseRequest(
+          request, {now});
+      } catch(e) {
+        error = e;
+      }
+      expect(result, 'result should not exist').to.be.null;
+      expect(error, 'error should exist').to.not.be.null;
+      error.message.should.equal('created was not in the request');
+    });
+
     it('should error if both created and headers are not set', () => {
       const authorization = 'Signature keyId="https://example.com/key/1",' +
         `signature="mockSignature"`;

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -836,6 +836,7 @@ describe('http-signature', () => {
     });
     it('should ignore unrecognized signature parameters', () => {
       const created = Math.floor(Date.now() / 1000);
+      // note: this test adds a single unrecognized signature parameter
       const unrecognized = 'unrecognized';
       const authorization = 'Signature keyId="https://example.com/key/1",' +
         'headers="date host (request-target) (created)",' +

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -390,7 +390,7 @@ describe('http-signature', () => {
     });
 
   });
-  describe('parseRequest api', function() {
+  describe('parseRequest API', function() {
     // takes the result of parseRequest and tests it
     const shouldBeParsed = parsed => {
       parsed.should.have.property('params');
@@ -834,6 +834,35 @@ describe('http-signature', () => {
       expect(error, 'error should exist').to.not.be.null;
       error.message.should.equal('keyId was not specified');
     });
+    it('should ignore unrecognized signature parameters', () => {
+      const created = Math.floor(Date.now() / 1000);
+      const unrecognized = 'unrecognized';
+      const authorization = 'Signature keyId="https://example.com/key/1",' +
+        'headers="date host (request-target) (created)",' +
+        `signature="mockSignature",created="${created}",` +
+        `unrecognized="${unrecognized}"`;
+      const request = {
+        headers: {
+          host: 'example.com:18443',
+          date: new Date().toUTCString(),
+          authorization
+        },
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const expectedHeaders = ['host', '(created)', '(request-target)'];
+      const parsed = httpSignatureHeader.parseRequest(
+        request, {headers: expectedHeaders});
+      expect(parsed, 'expected the parsing result to be an object').
+        to.be.an('object');
+      shouldBeParsed(parsed);
+      expect(parsed.params.created, 'expected created to be a string').
+        to.be.a('string');
+      parsed.params.created.should.equal(String(created));
+      parsed.signingString.should.contain(`(created): ${created}`);
+      parsed.signingString.should.not.contain(unrecognized);
+    });
+
     // this is for covered content
     it('default headers should be (created)', () => {
       const created = 1;

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -910,7 +910,7 @@ describe('http-signature', () => {
       expect(result, 'result should not exist').to.be.null;
       expect(error, 'error should exist').to.not.be.null;
       error.message.should.equal(
-        'headers parameter can not be a zero-length string');
+        'The "headers" parameter must not be a zero-length string.');
     });
 
     it('should error if both created and headers are not set', () => {


### PR DESCRIPTION
This adds 3 tests for 3 previously uncovered test cases.

1. properly encodes using header parameter order
    - This is pretty self explanatory: different header parameter orders should result in different signature strings even if the request is the same.
2. should ignore unrecognized signature parameters
    - in this one I added an unrecognized parameter to the signature header and it is ignored
    - we might want to add a test where we try to use the unrecognized parameter to ensure it errors
3. should error if headers parameter is zero-length
    - this is the reason this is a draft PR
    - Currently if a signature header's header parameter is zero-length the default of '(created)' is used
    - I changed this so if headers is not in the signature header it defaults to `created` however if headers is a zero-length string it now throws in parseRequest.
    - Should we throw in all cases if `headers=""`?


Normative statements:

2.1.6.  headers

>    OPTIONAL.  The `headers` parameter is used to specify the list of
>    HTTP headers included when generating the signature for the message.
>    If specified, it SHOULD be a lowercased, quoted list of HTTP header
>    fields, separated by a single space character.  If not specified,
>    implementations MUST operate as if the field were specified with a
>    single value, `(created)`, in the list of HTTP headers.  Note:
> 
>    1.  The list order is important, and MUST be specified in the order
>        the HTTP header field-value pairs are concatenated together
>        during Signature String Construction (Section 2.3) used during
>        signing and verifying.
> 
>    2.  A zero-length `headers` parameter value MUST NOT be used, since
>        it results in a signature of an empty string.

So throw on zero-length string or replace with `(created)`?