### PR TITLE
Error if (created)/(expires) is used with the wrong algorithm

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -419,7 +419,7 @@ function _signingString({
 }) {
   const {algorithm} = requestOptions;
   // we need to check that the covered content
-  // if allowed by the algorithm
+  // is allowed by the algorithm
   validateByAlgorithm(algorithm, includeHeaders);
   const result = [];
   for(const h of includeHeaders) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -522,8 +522,11 @@ function validateByAlgorithm(algorithm = '', includeHeaders = []) {
   }
   // these 3 older algorithms can not use some pseudo-headers
   const olderAlgorithms = [/$rsa/i, /$hmac/i, /$ecdsa/i];
+  // in order to prevent an attack with an extremely long string
+  // we only use the first 5 characters after a trim
+  const algorithmStart = algorithm.trim().substr(0, 5);
   for(const check of olderAlgorithms) {
-    if(check.test(algorithm)) {
+    if(check.test(algorithmStart)) {
       if(includeHeaders.includes('(created)')) {
         throw new HttpSignatureError(
           `Algorithm ${algorithm} does not support (created)`, 'SyntaxError');

--- a/lib/index.js
+++ b/lib/index.js
@@ -504,7 +504,8 @@ function validateDate(date, key) {
 }
 
 /**
- * Takes in an algorithm and the headers parameters from the signature.
+ * Ensures the given algorithm and the headers parameters from the signature
+ * are compatible with one another.
  *
  * @param {string} [algorithm=''] - The algorithm from the signature.
  * @param {Array<string>} [includeHeaders=[]] - The covered content from

--- a/lib/index.js
+++ b/lib/index.js
@@ -529,11 +529,13 @@ function validateByAlgorithm(algorithm = '', includeHeaders = []) {
     if(check.test(algorithmStart)) {
       if(includeHeaders.includes('(created)')) {
         throw new HttpSignatureError(
-          `Algorithm ${algorithm} does not support (created)`, 'SyntaxError');
+          `Algorithm ${algorithm} does not support "(created)".`,
+          'SyntaxError');
       }
       if(includeHeaders.includes('(expires)')) {
         throw new HttpSignatureError(
-          `Algorithm ${algorithm} does not support (expires)`, 'SyntaxError');
+          `Algorithm ${algorithm} does not support "(expires)".`,
+          'SyntaxError');
       }
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -417,6 +417,10 @@ function _signingString({
   includeHeaders, headers, method,
   host, path, requestOptions, validate
 }) {
+  const {algorithm} = requestOptions;
+  // we need to check that the covered content
+  // if allowed by the algorithm
+  validateByAlgorithm(algorithm, includeHeaders);
   const result = [];
   for(const h of includeHeaders) {
     if(h === '(request-target)') {
@@ -497,6 +501,40 @@ function validateDate(date, key) {
   }
   throw new TypeError(
     `"${key}" must be a UNIX timestamp or JavaScript Date.`);
+}
+
+/**
+ * Takes in an algorithm and the headers parameters from the signature.
+ *
+ * @param {string} [algorithm=''] - The algorithm from the signature.
+ * @param {Array<string>} [includeHeaders=[]] - The covered content from
+ *   the signature.
+ *
+ * @throws - If the includeHeaders contains a header not allowed
+ *   by the algorithm.
+ *
+ * @returns {boolean} Is the algorithm valid?
+*/
+function validateByAlgorithm(algorithm = '', includeHeaders = []) {
+  // algorithm is optional so no need to check if not specified
+  if(!algorithm) {
+    return true;
+  }
+  // these 3 older algorithms can not use some pseudo-headers
+  const olderAlgorithms = [/$rsa/i, /$hmac/i, /$ecdsa/i];
+  for(const check of olderAlgorithms) {
+    if(check.test(algorithm)) {
+      if(includeHeaders.includes('(created)')) {
+        throw new HttpSignatureError(
+          `Algorithm ${algorithm} does not support (created)`, 'SyntaxError');
+      }
+      if(includeHeaders.includes('(expires)')) {
+        throw new HttpSignatureError(
+          `Algorithm ${algorithm} does not support (expires)`, 'SyntaxError');
+      }
+    }
+  }
+  return true;
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -510,8 +510,8 @@ function validateDate(date, key) {
  * @param {Array<string>} [includeHeaders=[]] - The covered content from
  *   the signature.
  *
- * @throws - If the includeHeaders contains a header not allowed
- *   by the algorithm.
+ * @throws {HttpSignatureError} - If the includeHeaders contains a header
+ *   not allowed by the algorithm.
  *
  * @returns {boolean} Is the algorithm valid?
 */
@@ -521,7 +521,7 @@ function validateByAlgorithm(algorithm = '', includeHeaders = []) {
     return true;
   }
   // these 3 older algorithms can not use some pseudo-headers
-  const olderAlgorithms = [/$rsa/i, /$hmac/i, /$ecdsa/i];
+  const olderAlgorithms = [/^rsa/i, /^hmac/i, /^ecdsa/i];
   // in order to prevent an attack with an extremely long string
   // we only use the first 5 characters after a trim
   const algorithmStart = algorithm.trim().substr(0, 5);

--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -155,6 +155,70 @@ describe('http-signature', () => {
         `(request-target): get /1/2/3`);
     });
 
+    const algorithms = ['rsa', 'hmac', 'ecdsa'];
+
+    for(const algorithm of algorithms) {
+      it(`properly encodes when using algorithm ${algorithm}`, () => {
+        const requestOptions = {
+          headers: {},
+          algorithm,
+          method: 'GET',
+          url: 'https://example.com:18443/1/2/3',
+        };
+        const includeHeaders = ['host', '(algorithm)', '(request-target)'];
+        const stringToSign = httpSignatureHeader.createSignatureString(
+          {includeHeaders, requestOptions});
+        stringToSign.should.equal(
+          `host: example.com:18443\n(algorithm): ${algorithm}\n` +
+        `(request-target): get /1/2/3`);
+      });
+
+      it('throws when `(created)` is used with algorithm ' + algorithm, () => {
+        const requestOptions = {
+          headers: {},
+          algorithm,
+          method: 'GET',
+          url: 'https://example.com:18443/1/2/3',
+        };
+        const includeHeaders = ['(created)', '(algorithm)', '(request-target)'];
+        let result;
+        let error;
+        try {
+          result = httpSignatureHeader.createSignatureString(
+            {includeHeaders, requestOptions});
+        } catch(e) {
+          error = e;
+        }
+        expect(result).to.be.undefined;
+        expect(error).to.not.be.undefined;
+        error.message.should.equal(
+          `Algorithm ${algorithm} does not support "(created)".`);
+      });
+
+      it('throws when `(expires)` is used with algorithm ' + algorithm, () => {
+        const requestOptions = {
+          headers: {},
+          algorithm,
+          method: 'GET',
+          url: 'https://example.com:18443/1/2/3',
+        };
+        const includeHeaders = ['(expires)', '(algorithm)', '(request-target)'];
+        let result;
+        let error;
+        try {
+          result = httpSignatureHeader.createSignatureString(
+            {includeHeaders, requestOptions});
+        } catch(e) {
+          error = e;
+        }
+        expect(result).to.be.undefined;
+        expect(error).to.not.be.undefined;
+        error.message.should.equal(
+          `Algorithm ${algorithm} does not support "(expires)".`);
+      });
+
+    }
+
     it('properly encodes a header with multiple values', () => {
       const date = new Date().toUTCString();
       const requestOptions = {


### PR DESCRIPTION
> 2.3.  Signature String Construction
> 
>  signed HTTP message needs to be tolerant of some trivial
>    alterations during transmission as it goes through gateways, proxies,
>    and other entities.  These changes are often of little consequence
>    and very benign, but also often not visible to or detectable by
>    either the sender or the recipient.  Simply signing the entire
>    message that was transmitted by the sender is therefore not feasible:
>    Even very minor changes would result in a signature which cannot be
>    verified.
> 
>    This specification allows the sender to select which headers are
>    meaningful by including their names in the `headers` Signature
>    Parameter.  The headers appearing in this parameter are then used to
>    construct the intermediate Signature String, which is the data that
>    is actually signed.
> 
>    In order to generate the string that is signed with a key, the client
>    MUST use the values of each HTTP header field in the `headers`
>    Signature Parameter, in the order they appear in the `headers`
>    Signature Parameter.  It is out of scope for this document to dictate
>    what header fields an application will want to enforce, but
>    implementers SHOULD at minimum include the `(request-target)` and
>    `(created)` header fields if `algorithm` does not start with `rsa`,
>    `hmac`, or `ecdsa`. Otherwise, `(request-target)` and `date` SHOULD
>    be included in the signature.
> 
>    To include the HTTP request target in the signature calculation, use
>    the special `(request-target)` header field name.  To include the
>    signature creation time, use the special `(created)` header field
>    name.  To include the signature expiration time, use the special
>    `(expires)` header field name.
> 
>    1.  If the header field name is `(request-target)` then generate the
>        header field value by concatenating the lowercased :method, an
>        ASCII space, and the :path pseudo-headers (as specified in
>        HTTP/2, Section 8.1.2.3 [7]).  Note: For the avoidance of doubt,
>        lowercasing only applies to the :method pseudo-header and not to
>        the :path pseudo-header.
> 
>    2.  If the header field name is `(created)` and the `algorithm`
>        parameter starts with `rsa`, `hmac`, or `ecdsa` an implementation
>        MUST produce an error.  If the `created` Signature Parameter is
>        not specified, or is not an integer, an implementation MUST
>        produce an error.  Otherwise, the header field value is the
>        integer expressed by the `created` signature parameter.
> 
> 
> 
> 
> 
> Cavage & Sporny          Expires April 22, 2020                 [Page 7]
>  
> Internet-Draft            Signing HTTP Messages             October 2019
> 
> 
>    3.  If the header field name is `(expires)` and the `algorithm`
>        parameter starts with `rsa`, `hmac`, or `ecdsa` an implementation
>        MUST produce an error.  If the `expires` Signature Parameter is
>        not specified, or is not an integer, an implementation MUST
>        produce an error.  Otherwise, the header field value is the
>        integer expressed by the `created` signature parameter.


Throws if algorithm starts with `ecdsa`, `rsa`, or `hmac` and the includeHeaders contains `(created)` or `(expires)`.