### PR TITLE
Adds a test where multiple duplicate headers have become a comma separated list.

### DIFF
--- a/tests/10-test.spec.js
+++ b/tests/10-test.spec.js
@@ -124,6 +124,20 @@ describe('http-signature', () => {
         `host: example.com:18443\ndate: ${date}\nzero: `);
     });
 
+    it('properly encodes a header with multiple values', () => {
+      const date = new Date().toUTCString();
+      const multiple = 'true, false';
+      const requestOptions = {
+        headers: {date, multiple},
+        method: 'GET',
+        url: 'https://example.com:18443/1/2/3',
+      };
+      const stringToSign = httpSignatureHeader.createSignatureString(
+        {includeHeaders: ['host', 'date', 'multiple'], requestOptions});
+      stringToSign.should.equal(
+        `host: example.com:18443\ndate: ${date}\nmultiple: true, false`);
+    });
+
     it('properly encodes `(key-id)` with an iri', () => {
       const iri = 'https://example.com/key.pub';
       const requestOptions = {


### PR DESCRIPTION
When express receives an HTTP message with the same header listed multiple times:

```js
> GET / HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.74.0
> Accept: application/json
> Content-Type: application/json
> foo: true
> foo: false
```

express turn the multiple headers into a comma separated list:

```js
{
  host: 'localhost:3000',
  'user-agent': 'curl/7.74.0',
  accept: 'application/json',
  'content-type': 'application/json',
  foo: 'true, false'
}
[
  'Host',
  'localhost:3000',
  'User-Agent',
  'curl/7.74.0',
  'Accept',
  'application/json',
  'Content-Type',
  'application/json',
  'foo',
  'true',
  'foo',
  'false'
]
```

This adds a test to ensure that if this library receives one of these lists it handles it correctly.
