### PR TITLE
Add string validation for sigString.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - Library throws if the signature parameter headers is a zero-length string.
 - Library adds default `(created)` if no signature parameter header is present.
+- Validate `sigString` parameter in the `parseSignatureHeader` API.
 
 ### Added
 - Support for version 12 of the HTTP signature specification.

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,8 @@ module.exports = api;
  * @returns {object} Parsed options.
  */
 function parseSignatureHeader(sigString) {
+  assert.string(sigString, 'sigString');
+
   const ParamsState = {
     Name: 0,
     Quote: 1,


### PR DESCRIPTION
Without validation, an error is produced when attempting to access `sigString.length` if `sigString` is `undefined`.

https://github.com/digitalbazaar/http-signature-header/blob/master/lib/index.js#L63